### PR TITLE
Add interface to list all certificate orders

### DIFF
--- a/digicert-cli.gemspec
+++ b/digicert-cli.gemspec
@@ -20,7 +20,9 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   spec.executables   = "digicert"
 
+  spec.add_development_dependency "dotenv"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 2.0"
 end

--- a/lib/digicert/cli.rb
+++ b/lib/digicert/cli.rb
@@ -1,10 +1,18 @@
+require "optparse"
 require "digicert"
+
 require "digicert/cli/auth"
+require "digicert/cli/command"
 
 module Digicert
   module CLI
-    def self.start(*arguments)
-      puts arguments.inspect
+    def self.start(*args)
+      command = args.shift.strip rescue "help"
+
+      Digicert::CLI::Command.load
+      response = Digicert::CLI::Command.run(command, args)
+
+      $stdout.write(response)
     end
   end
 end

--- a/lib/digicert/cli/auth.rb
+++ b/lib/digicert/cli/auth.rb
@@ -1,3 +1,6 @@
+require "dotenv/load"
+
 Digicert.configure do |config|
   config.api_key = ENV["DIGICERT_API_KEY"]
+  config.response_type = "hash"
 end

--- a/lib/digicert/cli/command.rb
+++ b/lib/digicert/cli/command.rb
@@ -1,0 +1,33 @@
+require "digicert/cli/command/order"
+
+module Digicert
+  module CLI
+    module Command
+      def self.load
+        register_available_commands
+      end
+
+      def self.run(command, args = {})
+        command_klass, method = extract_command(command)
+        command_klass.new(args).send(method)
+      end
+
+      def self.parse(command)
+        commands[command.to_sym]
+      end
+
+      def self.commands
+        @@commands ||= {}
+      end
+
+      def self.register_available_commands
+        commands[:order] = { klass: Digicert::CLI::Command::Order }
+      end
+
+      def self.extract_command(command)
+        base_command, method = command.split(":")
+        [parse(base_command)[:klass], method]
+      end
+    end
+  end
+end

--- a/lib/digicert/cli/command/order.rb
+++ b/lib/digicert/cli/command/order.rb
@@ -1,0 +1,17 @@
+module Digicert
+  module CLI
+    module Command
+      class Order
+        attr_reader :options
+
+        def initialize(attributes = {})
+          @options = attributes
+        end
+
+        def list
+          Digicert::Order.all
+        end
+      end
+    end
+  end
+end

--- a/spec/digicert/cli_spec.rb
+++ b/spec/digicert/cli_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Digicert::CLI do
+  describe ".start" do
+    it "sends run message to command handler" do
+      shell_command = %w(order:find -n order_id)
+      allow(Digicert::CLI::Command).to receive(:run)
+
+      Digicert::CLI.start(*shell_command)
+
+      expect(
+        Digicert::CLI::Command,
+      ).to have_received(:run).with(shell_command.shift, shell_command)
+    end
+  end
+end

--- a/spec/digicert/command/order_spec.rb
+++ b/spec/digicert/command/order_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe Digicert::CLI::Command do
+  describe "#list" do
+    it "sends all message to digicert order interface" do
+      allow(Digicert::Order).to receive(:all)
+
+      order = Digicert::CLI::Command::Order.new
+      order.list
+
+      expect(Digicert::Order).to have_received(:all)
+    end
+  end
+end

--- a/spec/digicert/command_spec.rb
+++ b/spec/digicert/command_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Digicert::CLI::Command do
+  describe ".run" do
+    it "runs the command through proper handler" do
+      mock_cli_order_command_messages(:new, :list)
+      Digicert::CLI::Command.run("order:list")
+
+      expect(Digicert::CLI::Command::Order.new).to have_received(:list)
+    end
+  end
+
+  def mock_cli_order_command_messages(*messages)
+    allow(Digicert::CLI::Command::Order).to receive_message_chain(messages)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "webmock/rspec"
 require "bundler/setup"
 require "digicert/cli"
 
@@ -7,5 +8,9 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before(:all) do
+    Digicert::CLI::Command.register_available_commands
   end
 end


### PR DESCRIPTION
This commit adds the command line interface to list all orders from Digicert Order API. There is nothing fancy, this is the incremental commit toward building more usable interface. For now this allows us to retrieve the list of orders as simple as

```sh
bin/digicert order:list
```