### PR TITLE
Add specific order retrieval interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@
 
 The CLI for the Digicert API
 
+## Usages
+
+### Order
+
+This CLI provides an easier interface to list the orders from the Digicert API.
+To retrieve the list of the certificate orders please we can use
+
+```sh
+bin/digicert order:list
+```
+
+In case you have a specific `order_id` and you want to retrieve the details for
+that orders, then please use the list interface with `-o` option.
+
+```sh
+bin/digicert order:list -o 123_456_789
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/digicert/cli/command/order.rb
+++ b/lib/digicert/cli/command/order.rb
@@ -2,14 +2,26 @@ module Digicert
   module CLI
     module Command
       class Order
-        attr_reader :options
+        attr_reader :order_id
 
         def initialize(attributes = {})
-          @options = attributes
+          @order_id = attributes[:order_id]
         end
 
         def list
-          Digicert::Order.all
+          find_order || order_api.all
+        end
+
+        private
+
+        def find_order
+          if order_id
+            order_api.fetch(order_id)
+          end
+        end
+
+        def order_api
+          Digicert::Order
         end
       end
     end

--- a/spec/digicert/command/order_spec.rb
+++ b/spec/digicert/command/order_spec.rb
@@ -2,13 +2,27 @@ require "spec_helper"
 
 RSpec.describe Digicert::CLI::Command do
   describe "#list" do
-    it "sends all message to digicert order interface" do
-      allow(Digicert::Order).to receive(:all)
+    context "without order_id attributes" do
+      it "sends all message to digicert order interface" do
+        allow(Digicert::Order).to receive(:all)
 
-      order = Digicert::CLI::Command::Order.new
-      order.list
+        order = Digicert::CLI::Command::Order.new
+        order.list
 
-      expect(Digicert::Order).to have_received(:all)
+        expect(Digicert::Order).to have_received(:all)
+      end
+    end
+
+    context "with an order id" do
+      it "sends fetch message to digicert order interface" do
+        order_id = 123_456_789
+        allow(Digicert::Order).to receive(:fetch).and_return("order")
+
+        order = Digicert::CLI::Command::Order.new(order_id: order_id)
+        order.list
+
+        expect(Digicert::Order).to have_received(:fetch).with(order_id)
+      end
     end
   end
 end


### PR DESCRIPTION
This commit adds the option support to the order interface, so now we can list all orders using `order:list` and if we want to retrieve a specific order then can pass that id as an option.

```sh
bin/digicert order:list -o 123_456_789
```