### PR TITLE
Add interface to filter certificate orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ that orders, then please use the list interface with `-o` option.
 bin/digicert order:list -o 123_456_789
 ```
 
+Digicert does not have any a direct interface to filter certificate orders,
+but we have added the following interface to partially support order filtering.
+It usages the `list` interface to retrieve all of the orders and that apply
+filters on top of those results. Currently supported options are `common_name`
+and `product_type`.
+
+```sh
+bin/digicert order:find -c "ribosetest.com" -p "ssl_plus"
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/digicert/cli/auth.rb
+++ b/lib/digicert/cli/auth.rb
@@ -2,5 +2,4 @@ require "dotenv/load"
 
 Digicert.configure do |config|
   config.api_key = ENV["DIGICERT_API_KEY"]
-  config.response_type = "hash"
 end

--- a/lib/digicert/cli/command.rb
+++ b/lib/digicert/cli/command.rb
@@ -54,6 +54,8 @@ module Digicert
       def self.global_options
         [
           ["-o", "--order_id ORDER_ID",  "The Digicert Order Id"],
+          ["-c", "--common_name COMMON_NAME", "The common name for the order"],
+          ["-p", "--product_type NAME_ID", "The Digicert product name Id"],
         ]
       end
     end

--- a/lib/digicert/cli/command/order.rb
+++ b/lib/digicert/cli/command/order.rb
@@ -2,14 +2,19 @@ module Digicert
   module CLI
     module Command
       class Order
-        attr_reader :order_id
+        attr_reader :order_id, :options
 
         def initialize(attributes = {})
-          @order_id = attributes[:order_id]
+          @options = attributes
+          @order_id = options[:order_id]
         end
 
         def list
           find_order || order_api.all
+        end
+
+        def find
+          find_order || filter_order
         end
 
         private
@@ -18,6 +23,22 @@ module Digicert
           if order_id
             order_api.fetch(order_id)
           end
+        end
+
+        def filter_order
+          list.select do |order|
+            filter_by_common_name(order) && filter_by_product_type(order)
+          end
+        end
+
+        def filter_by_common_name(order)
+          !options[:common_name] ||
+            options[:common_name] == order.certificate.common_name
+        end
+
+        def filter_by_product_type(order)
+          !options[:product_type] ||
+            options[:product_type] == order.product_name_id
         end
 
         def order_api


### PR DESCRIPTION
Digicert does not have any a direct interface to filter certificate orders, but this commit adds an interface to partially support order filtering option, it usages the `list` interface to retrieve all of the orders and that apply filters on top of results and returns to via the interface. The supported options are `-c` and `-p`

```sh
bin/digicert order:find -c "ribosetest.com" -p "ssl_plus"
```