### PR TITLE
Downloading a specific certificate content

### DIFF
--- a/lib/digicert/cli/command.rb
+++ b/lib/digicert/cli/command.rb
@@ -1,5 +1,6 @@
 require "optparse"
 require "digicert/cli/command/order"
+require "digicert/cli/command/certificate"
 
 module Digicert
   module CLI
@@ -25,6 +26,7 @@ module Digicert
 
       def self.register_available_commands
         commands[:order] = { klass: Digicert::CLI::Command::Order }
+        commands[:certificate] = { klass: Digicert::CLI::Command::Certificate }
       end
 
       def self.extract_command(command)

--- a/lib/digicert/cli/command/certificate.rb
+++ b/lib/digicert/cli/command/certificate.rb
@@ -1,0 +1,26 @@
+module Digicert
+  module CLI
+    module Command
+      class Certificate
+        attr_reader :order_id, :options
+
+        def initialize(attributes = {})
+          @options = attributes
+          @order_id = options[:order_id]
+        end
+
+        def retrieve
+          if order_id
+            downloader_klass.fetch_content(order_id)
+          end
+        end
+
+        private
+
+        def downloader_klass
+          Digicert::CertificateDownloader
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit implement the certificate content retrieving interface, but there are still some part that are not clear yet, like what is the approach to download a certificate, what sort of functionality we want to allow through this interface and also do we write the content or just return it, and also something with the file path