### PR TITLE
Add `digicert` and `terminal-table` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in digicert-cli.gemspec
 gemspec
-gem "digicert", github: "riboseinc/digicert"

--- a/digicert-cli.gemspec
+++ b/digicert-cli.gemspec
@@ -20,8 +20,11 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   spec.executables   = "digicert"
 
-  spec.add_development_dependency "dotenv"
+  spec.add_dependency "digicert", "~> 0.1.1"
+  spec.add_dependency "terminal-table"
+
   spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "dotenv"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.0"

--- a/lib/digicert/cli.rb
+++ b/lib/digicert/cli.rb
@@ -1,6 +1,7 @@
 require "optparse"
 require "digicert"
 
+require "digicert/cli/util"
 require "digicert/cli/auth"
 require "digicert/cli/command"
 
@@ -10,9 +11,10 @@ module Digicert
       command = args.shift.strip rescue "help"
 
       Digicert::CLI::Command.load
-      response = Digicert::CLI::Command.run(command, args)
+      response_body = Digicert::CLI::Command.run(command, args)
 
-      $stdout.write(response)
+      $stdout.write(response_body)
+      $stdout.write("\n")
     end
   end
 end

--- a/lib/digicert/cli/util.rb
+++ b/lib/digicert/cli/util.rb
@@ -1,0 +1,16 @@
+require "terminal-table"
+
+module Digicert
+  module CLI
+    module Util
+      def self.make_it_pretty(headings:, rows:, table_wdith: 80)
+        Terminal::Table.new do |table|
+          table.headings = headings
+          table.style = { width: table_wdith }
+
+          table.rows = rows
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Now that we have released our gems to rubygems, so let's start to use that one and let's also add `terminal-table` gems to display a nicely formatted output for collections.

This commit also updated the existing `CLI` class and this one also adds a `Util` class to provide the terminal helper in one place.