### PR TITLE
Add `reissue-order` interface for existing order

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ the `id` for the resource.
 digicert find-order -c "ribosetest.com" -p "ssl_plus" --status expired --quiet
 ```
 
+### Reissue an order
+
+To reissue an existing order, we can use the following interface.
+
+```sh
+digicert reissue-order --order_id 12345
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/digicert/cli/command.rb
+++ b/lib/digicert/cli/command.rb
@@ -1,5 +1,6 @@
 require "optparse"
 require "digicert/cli/order_finder"
+require "digicert/cli/order_reissuer"
 
 module Digicert
   module CLI
@@ -26,6 +27,7 @@ module Digicert
       def self.register_available_commands
         commands["find-order"] = { klass: "OrderFinder", method: :find }
         commands["find-orders"] = { klass: "OrderFinder", method: :list }
+        commands["reissue-order"] = { klass: "OrderReissuer", method: :create }
       end
 
       def self.extract_command(command)

--- a/lib/digicert/cli/order_reissuer.rb
+++ b/lib/digicert/cli/order_reissuer.rb
@@ -1,0 +1,26 @@
+module Digicert
+  module CLI
+    class OrderReissuer
+      attr_reader :order_id, :options
+
+      def initialize(order_id:, **options)
+        @order_id = order_id
+        @options = options
+      end
+
+      def create
+        reissue = Digicert::OrderReissuer.create(order_id: order_id)
+        apply_output_options(reissue)
+      end
+
+      private
+
+      def apply_output_options(reissue)
+        if reissue
+          request_id = reissue.requests.first.id
+          "Reissue request #{request_id} created for order - #{order_id}"
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/reissue_order_spec.rb
+++ b/spec/acceptance/reissue_order_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe "Reissue order" do
+  describe "Reissuing an existing order" do
+    it "reissues the order and print out the details" do
+      command = %w(reissue-order --order_id 123456)
+      allow(Digicert::OrderReissuer).to receive(:create)
+
+      Digicert::CLI.start(*command)
+
+      expect(
+        Digicert::OrderReissuer,
+      ).to have_received(:create).with(order_id: "123456")
+    end
+  end
+end

--- a/spec/digicert/order_reissuer_spec.rb
+++ b/spec/digicert/order_reissuer_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe Digicert::CLI::OrderReissuer do
+  describe "#create" do
+    context "with only order id passed" do
+      it "sends create message to digicert order reissuer" do
+        order_id = 123_456
+        allow(Digicert::OrderReissuer).to receive(:create)
+
+        reissuer = Digicert::CLI::OrderReissuer.new(order_id: order_id)
+        reissuer.create
+
+        expect(
+          Digicert::OrderReissuer
+        ).to have_received(:create).with(order_id: order_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the `reissue-order` interface for an existing order. Once the order reissue request is created then it will print out a message with the request id on it.

In the upcoming PRs we will more output option where user can specify if they want to download the reissued certificate.

```sh
bin/digicert reissue-order --order_id 123456789
```