### PR TITLE
Reissue and download a certificate order

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ To reissue an existing order, we can use the following interface.
 digicert order reissue --order_id 12345
 ```
 
+### Reissue and download a certificate
+
+To reissue an order and save that reissued certificate to a specific path we can
+use the following interface.
+
+```sh
+digicert order reissue --order_id 123456 --output /full/download/path
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/digicert/cli/certificate_downloader.rb
+++ b/lib/digicert/cli/certificate_downloader.rb
@@ -44,9 +44,7 @@ module Digicert
       end
 
       def print_message(message)
-        if options.fetch(:print_enable, true)
-          puts(message)
-        end
+        Digicert::CLI::Util.print_message(message)
       end
     end
   end

--- a/lib/digicert/cli/command.rb
+++ b/lib/digicert/cli/command.rb
@@ -51,6 +51,8 @@ module Digicert
           ["-s", "--status STATUS", "Use to specify the order status"],
           ["-c", "--common_name COMMON_NAME", "The common name for the order"],
           ["-p", "--product_type NAME_ID", "The Digicert product name Id"],
+          ["-f", "--fetch", "Flag to fetch resource after certian operation"],
+          ["-path", "--output DOWNLOAD_PATH", "Path to download the certificate"]
         ]
       end
     end

--- a/lib/digicert/cli/order_reissuer.rb
+++ b/lib/digicert/cli/order_reissuer.rb
@@ -1,25 +1,63 @@
+require "date"
+require "digicert/cli/order_retriever"
+require "digicert/cli/certificate_downloader"
+
 module Digicert
   module CLI
     class OrderReissuer
-      attr_reader :order_id, :options
+      attr_reader :order_id, :options, :output_path
 
       def initialize(order_id:, **options)
         @order_id = order_id
         @options = options
+        @output_path = options.fetch(:output, "/tmp")
       end
 
       def create
-        reissue = Digicert::OrderReissuer.create(order_id: order_id)
-        apply_output_options(reissue)
+        apply_output_options(reissue_an_order)
+      end
+
+      def self.create(attributes)
+        new(attributes).create
       end
 
       private
 
+      def reissue_an_order
+        Digicert::OrderReissuer.create(order_id: order_id)
+      end
+
       def apply_output_options(reissue)
         if reissue
-          request_id = reissue.requests.first.id
-          "Reissue request #{request_id} created for order - #{order_id}"
+          print_request_details(reissue.requests.first)
+          fetch_and_download_certificate(reissue.id)
         end
+      end
+
+      def print_request_details(request)
+        request_id = request.id
+        puts "Reissue request #{request_id} created for order - #{order_id}"
+      end
+
+      def fetch_and_download_certificate(reissued_order_id)
+        if options[:output]
+          order = fetch_reissued_order(reissued_order_id)
+          download_certificate_order(order.certificate.id)
+        end
+      end
+
+      def fetch_reissued_order(reissued_order_id)
+        Digicert::CLI::OrderRetriever.fetch(
+          reissued_order_id,
+          wait_time: options[:wait_time],
+          number_of_times: options[:number_of_times]
+        )
+      end
+
+      def download_certificate_order(certificate_id)
+        Digicert::CLI::CertificateDownloader.download(
+          filename: order_id, path: output_path, certificate_id: certificate_id
+        )
       end
     end
   end

--- a/lib/digicert/cli/order_retriever.rb
+++ b/lib/digicert/cli/order_retriever.rb
@@ -5,8 +5,8 @@ module Digicert
     class OrderRetriever
       def initialize(order_id, attributes)
         @order_id = order_id
-        @wait_time = attributes.fetch(:wait_time, 10)
-        @number_of_times = attributes.fetch(:number_of_times, 5)
+        @wait_time = attributes[:wait_time] || 10
+        @number_of_times = attributes[:number_of_times] || 5
       end
 
       def fetch

--- a/spec/acceptance/order_spec.rb
+++ b/spec/acceptance/order_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Order" do
 
   describe "reissuing an order" do
     it "reissues the order and print out the details" do
-      command = %w(order reissue --order_id 123456)
+      command = %w(order reissue --order_id 123456 -f --output /tmp/downloads)
       allow(Digicert::OrderReissuer).to receive(:create)
 
       Digicert::CLI.start(*command)

--- a/spec/digicert/order_reissuer_spec.rb
+++ b/spec/digicert/order_reissuer_spec.rb
@@ -15,5 +15,45 @@ RSpec.describe Digicert::CLI::OrderReissuer do
         ).to have_received(:create).with(order_id: order_id)
       end
     end
+
+    context "with order id and --fetch option" do
+      it "reissue order and fetch the updated order" do
+        order_id = 456_789
+
+        mock_order_fetch_and_download_requests(order)
+        stub_digicert_order_reissue_api(order_id, order_attributes(order))
+        allow(Digicert::CLI::CertificateDownloader).to receive(:download)
+
+        Digicert::CLI::OrderReissuer.create(
+          order_id: order_id, output: "/tmp", number_of_times: 1, wait_time: 1
+        )
+
+        expect(Digicert::CLI::CertificateDownloader).
+          to have_received(:download).
+          with(hash_including(certificate_id: order.certificate.id))
+      end
+    end
+  end
+
+  def mock_order_fetch_and_download_requests(order)
+    allow(Digicert::Order).to receive(:fetch).and_return(order)
+    allow(Digicert::CLI::OrderRetriever).to receive(:fetch).and_return(order)
+  end
+
+  def order(order_id = 123_456)
+    stub_digicert_order_fetch_api(order_id)
+    @order ||= Digicert::Order.fetch(order_id)
+  end
+
+  def order_attributes(order)
+    {
+      certificate: {
+        common_name: order.certificate.common_name,
+        dns_names: order.certificate.dns_names,
+        csr: order.certificate.csr,
+        signature_hash: order.certificate.signature_hash,
+        server_platform: { id: 45 }
+      }
+    }
   end
 end


### PR DESCRIPTION
Digicer allow us to reissue and download an existing certificate, the reissuing interface is simple, all we need is create a post request and digicert will respond with the request details.

But reissuing and instantly trying to download any certificate requires some additional work. When we submit a reissuing request then digicert needs some time to actually reissue the order and it doesn't directly have any interface to fetch recently reissued order / certificate.

This commit adds the interface to perform all of this task in a single command, if our goal is to reissue an order then we can do that by

```sh
digicert order reissue --order_id 123456789
```
But if we want reissue an order and then fetch and download it then we can do that by specify the `--output` option, which takes a full path and it performs the necessary work to fetch the order and then download it to the provided path.

```sh
digicert order reissue --o 123456789 --output /full/path/to/download
```