### PR TITLE
Add certificate file content downloader

### DIFF
--- a/lib/digicert/cli/certificate_downloader.rb
+++ b/lib/digicert/cli/certificate_downloader.rb
@@ -1,0 +1,53 @@
+module Digicert
+  module CLI
+    class CertificateDownloader
+      def initialize(certificate_id:, path:, **options)
+        @path = path
+        @options = options
+        @certificate_id = certificate_id
+        @filename = options.fetch(:filename, certificate_id)
+      end
+
+      def download
+        if certificate_contents
+          write_certificate_contents(certificate_contents)
+        end
+      end
+
+      def self.download(attributes)
+        new(attributes).download
+      end
+
+      private
+
+      attr_reader :certificate_id, :path, :filename, :options
+
+      def certificate_contents
+        @certificate_contents ||=
+          Digicert::CertificateDownloader.fetch_content(certificate_id)
+      end
+
+      def write_certificate_contents(contents)
+        print_message("Downloaded certificate to:")
+
+        write_to_path("root", contents[:root_certificate])
+        write_to_path("certificate", contents[:certificate])
+        write_to_path("intermediate", contents[:intermediate_certificate])
+      end
+
+      def write_to_path(key, content)
+        certificate_name = [filename, key, "crt"].join(".")
+        certificate_path = [path, certificate_name].join("/")
+
+        print_message(certificate_path)
+        File.open(certificate_path, "w") { |file| file.write(content) }
+      end
+
+      def print_message(message)
+        if options.fetch(:print_enable, true)
+          puts(message)
+        end
+      end
+    end
+  end
+end

--- a/spec/digicert/certificate_downloader_spec.rb
+++ b/spec/digicert/certificate_downloader_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+require "digicert/cli/certificate_downloader"
+
+RSpec.describe Digicert::CLI::CertificateDownloader do
+  describe ".download" do
+    it "downloads the certificate to the specified path" do
+      certificate_id = 123_456_789
+      allow(File).to receive(:open)
+      mock_digicert_certificate_download_api(certificate_id)
+
+      Digicert::CLI::CertificateDownloader.download(
+        print_enable: false,
+        path: download_path,
+        certificate_id: certificate_id,
+      )
+
+      expect(File).to have_received(:open).thrice
+    end
+  end
+
+  def download_path
+    File.expand_path("../../tmp", __FILE__).to_s
+  end
+
+  def mock_digicert_certificate_download_api(certificate_id)
+    stub_digicert_certificate_download_by_format(
+      certificate_id, "pem_all", "pem"
+    )
+  end
+end


### PR DESCRIPTION
This commit adds a certificate content downloader, this takes an option hash as an arguments, which expects `certificate_id`, `path` and optional `filename`, and then fetches the certificate contents and write those as `crt` file to the provided path.

The current format for the filenames are `[filename].[certificate_type].crt`.