### PR TITLE
Add interface to retrieve order in interval

### DIFF
--- a/lib/digicert/cli/order_retriever.rb
+++ b/lib/digicert/cli/order_retriever.rb
@@ -1,0 +1,48 @@
+require "date"
+
+module Digicert
+  module CLI
+    class OrderRetriever
+      def initialize(order_id, attributes)
+        @order_id = order_id
+        @wait_time = attributes.fetch(:wait_time, 10)
+        @number_of_times = attributes.fetch(:number_of_times, 5)
+      end
+
+      def fetch
+        fetch_order_in_interval
+        reissued_order
+      end
+
+      def self.fetch(order_id, attributes)
+        new(order_id, **attributes).fetch
+      end
+
+      private
+
+      attr_reader :order_id, :number_of_times, :wait_time, :reissued_order
+
+      def fetch_order_in_interval
+        number_of_times.to_i.times do |number|
+          sleep wait_time.to_i
+          print_message("Fetch attempt #{number + 1}..")
+          order = Digicert::Order.fetch(order_id)
+
+          if recently_reissued?(order.last_reissued_date)
+            break @reissued_order = order
+          end
+        end
+      end
+
+      def recently_reissued?(datetime)
+        if datetime
+          ((Time.now - DateTime.parse(datetime).to_time) / 60).ceil < 3
+        end
+      end
+
+      def print_message(message)
+        Digicert::CLI::Util.print_message(message)
+      end
+    end
+  end
+end

--- a/lib/digicert/cli/util.rb
+++ b/lib/digicert/cli/util.rb
@@ -11,6 +11,10 @@ module Digicert
           table.rows = rows
         end
       end
+
+      def self.print_message(message)
+        puts(message)
+      end
     end
   end
 end

--- a/spec/digicert/order_retriever_spec.rb
+++ b/spec/digicert/order_retriever_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require "digicert/cli/order_retriever"
+
+RSpec.describe Digicert::CLI::OrderRetriever do
+  describe ".fetch" do
+    context "with number_of_times option specfied" do
+      it "tries to retrieve the order by specfied number of times" do
+        allow(Digicert::Order).to receive(:fetch).and_return(order)
+
+        Digicert::CLI::OrderRetriever.fetch(
+          order.id, number_of_times: 2, wait_time: 1
+        )
+
+        expect(Digicert::Order).to have_received(:fetch).twice
+      end
+    end
+  end
+
+  def order(order_id = 123_456)
+    stub_digicert_order_fetch_api(order_id)
+    @order ||= Digicert::Order.fetch(order_id)
+  end
+end


### PR DESCRIPTION
When we submit a request to reissue an order then the order might not be instantly reissued, and it might also takes time to reissue the order, so we need a way to fetch the updated order in a certain interval and then maybe download it or do something else.

This commit adds a `OrderRetriever`, which expose `fetch` interface and that allows us to specify the `number_of_times` and `wait_time` and then it try to fetch the order as we specify the details.