### PR TITLE
Add interface to fetch an order's CSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ use the following interface.
 digicert order reissue --order_id 123456 --output /full/download/path
 ```
 
+### CSR
+
+#### Fetch an order's CSR
+
+If we need to retrieve the `CSR` for any specific order then we can use and it
+will return the content in the terminal.
+
+```sh
+digicert csr fetch --order_id 123456
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/digicert/cli/command.rb
+++ b/lib/digicert/cli/command.rb
@@ -1,5 +1,6 @@
 require "optparse"
 require "digicert/cli/order"
+require "digicert/cli/csr"
 
 module Digicert
   module CLI
@@ -16,7 +17,7 @@ module Digicert
       end
 
       def self.command_handlers
-        @commands ||= { order: "Order" }
+        @commands ||= { order: "Order", csr: "CSR"}
       end
 
       def self.command_handler(command)

--- a/lib/digicert/cli/csr.rb
+++ b/lib/digicert/cli/csr.rb
@@ -1,0 +1,23 @@
+module Digicert
+  module CLI
+    class CSR
+      def initialize(order_id:)
+        @order_id = order_id
+      end
+
+      def fetch
+        if order
+          order.certificate.csr
+        end
+      end
+
+      private
+
+      attr_reader :order_id
+
+      def order
+        @order ||= Digicert::Order.fetch(order_id)
+      end
+    end
+  end
+end

--- a/spec/acceptance/csr_spec.rb
+++ b/spec/acceptance/csr_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe "CSR" do
+  describe "fetching a CSR" do
+    it "fetches the CSR for specified order" do
+      command = %w(csr fetch --order_id 123456)
+      allow(Digicert::CLI::CSR).to receive_message_chain(:new, :fetch)
+
+      Digicert::CLI.start(*command)
+
+      expect(Digicert::CLI::CSR).to have_received(:new).with(order_id: "123456")
+    end
+  end
+end

--- a/spec/digicert/csr_spec.rb
+++ b/spec/digicert/csr_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Digicert::CLI::CSR do
+  describe "#fetch" do
+    it "fetches the csr for an existing order" do
+      order_id = 123456
+      stub_digicert_order_fetch_api(order_id)
+
+      csr = Digicert::CLI::CSR.new(order_id: order_id).fetch
+
+      expect(csr).not_to be_nil
+      expect(csr).to eq("------ [CSR HERE] ------")
+    end
+  end
+end


### PR DESCRIPTION
This commit adds an interface to fetch the CSR for the supplied order id and then return it to the console. To fetch the CSR we will require us to provide an order id or else it will throw an error.

```sh
order csr fetch --order_id 123456
```