### PR TITLE
Do not show every option in every resource

### DIFF
--- a/lib/digicert/cli.rb
+++ b/lib/digicert/cli.rb
@@ -3,6 +3,7 @@ require "digicert"
 
 require "digicert/cli/util"
 require "digicert/cli/auth"
+require "digicert/cli/base"
 require "digicert/cli/command"
 
 module Digicert

--- a/lib/digicert/cli/base.rb
+++ b/lib/digicert/cli/base.rb
@@ -1,0 +1,23 @@
+module Digicert
+  module CLI
+    class Base
+      attr_reader :order_id, :options
+
+      def initialize(attributes = {})
+        @options = attributes
+        @order_id = options.delete(:order_id)
+
+        extract_local_attributes(options)
+      end
+
+      def self.local_options
+        []
+      end
+
+      private
+
+      def extract_local_attributes(options)
+      end
+    end
+  end
+end

--- a/lib/digicert/cli/command.rb
+++ b/lib/digicert/cli/command.rb
@@ -7,7 +7,7 @@ module Digicert
     module Command
       def self.run(command, subcommand, args = {})
         command_klass = command_handler(command)
-        attributes = parse_option_arguments(args)
+        attributes = parse_option_arguments(command_klass, args)
 
         command_klass.new(attributes).send(subcommand.to_sym)
       end
@@ -26,13 +26,14 @@ module Digicert
         )
       end
 
-      def self.parse_option_arguments(args)
+      def self.parse_option_arguments(handler_klass, args)
         attributes = {}
 
         option_parser = OptionParser.new do |parser|
-          parser.banner = "Usage: digicert resource:action [options]"
+          parser.banner = "Usage: digicert resource action [options]"
+          options = global_options + handler_klass.local_options
 
-          global_options.each do |option|
+          options.each do |option|
             attribute_name = option[1].split.first.gsub("--", "").to_sym
             parser.on(*option) { |value| attributes[attribute_name] = value}
           end
@@ -47,15 +48,8 @@ module Digicert
 
       def self.global_options
         [
+          ["-c", "--common_name COMMON_NAME", "The domain name"],
           ["-o", "--order_id ORDER_ID",  "The Digicert Order Id"],
-          ["-q", "--quiet",  "Flag to return resource Id only"],
-          ["-s", "--status STATUS", "Use to specify the order status"],
-          ["-c", "--common_name COMMON_NAME", "The common name for the order"],
-          ["-p", "--product_type NAME_ID", "The Digicert product name Id"],
-          ["-f", "--fetch", "Flag to fetch resource after certian operation"],
-          ["-crt", "--crt CSR_FILE", "Full path for the csr file"],
-          ["-k", "--key KEY_FILE_PATH", "Path to the rsa key file"],
-          ["-path", "--output DOWNLOAD_PATH", "Path to download the certificate"]
         ]
       end
     end

--- a/lib/digicert/cli/csr.rb
+++ b/lib/digicert/cli/csr.rb
@@ -1,11 +1,6 @@
 module Digicert
   module CLI
-    class CSR
-      def initialize(order_id:, **options)
-        @order_id = order_id
-        @rsa_key = options.fetch(:key, nil)
-      end
-
+    class CSR < Digicert::CLI::Base
       def fetch
         if order
           order.certificate.csr
@@ -18,9 +13,20 @@ module Digicert
         end
       end
 
+      def self.local_options
+        [
+          ["-k", "--key KEY_FILE_PATH", "Path to the rsa key file"],
+          ["-r", "--crt CSR_FILE", "Full path for the csr file"]
+        ]
+      end
+
       private
 
-      attr_reader :order_id, :rsa_key
+      attr_reader :rsa_key
+
+      def extract_local_attributes(options)
+        @rsa_key = options.fetch(:key, nil)
+      end
 
       def order
         @order ||= Digicert::Order.fetch(order_id)

--- a/lib/digicert/cli/order.rb
+++ b/lib/digicert/cli/order.rb
@@ -3,14 +3,7 @@ require "digicert/cli/order_reissuer"
 
 module Digicert
   module CLI
-    class Order
-      attr_reader :order_id, :options
-
-      def initialize(attributes = {})
-        @options = attributes
-        @order_id = options.delete(:order_id)
-      end
-
+    class Order < Digicert::CLI::Base
       def list
         filtered_orders = apply_filters(orders)
         display_orders_in_table(filtered_orders)
@@ -25,6 +18,17 @@ module Digicert
         Digicert::CLI::OrderReissuer.new(
           order_id: order_id, **options
         ).create
+      end
+
+      def self.local_options
+        [
+          ["-q", "--quiet",  "Flag to return resource Id only"],
+          ["-s", "--status STATUS", "Use to specify the order status"],
+          ["-n", "--product_type NAME_ID", "The Digicert product name Id"],
+          ["-f", "--fetch", "Flag to fetch resource after certian operation"],
+          ["-r", "--crt CSR_FILE", "Full path for the csr file"],
+          ["-p", "--output DOWNLOAD_PATH", "Path to download the certificate"]
+        ]
       end
 
       private

--- a/lib/digicert/cli/order_reissuer.rb
+++ b/lib/digicert/cli/order_reissuer.rb
@@ -4,16 +4,7 @@ require "digicert/cli/certificate_downloader"
 
 module Digicert
   module CLI
-    class OrderReissuer
-      attr_reader :order_id, :csr_file, :options, :output_path
-
-      def initialize(order_id:, **options)
-        @order_id = order_id
-        @options = options
-        @csr_file = options.fetch(:crt, nil)
-        @output_path = options.fetch(:output, "/tmp")
-      end
-
+    class OrderReissuer < Digicert::CLI::Base
       def create
         apply_output_options(reissue_an_order)
       end
@@ -23,6 +14,13 @@ module Digicert
       end
 
       private
+
+      attr_reader :csr_file, :output_path
+
+      def extract_local_attributes(options)
+        @csr_file = options.fetch(:crt, nil)
+        @output_path = options.fetch(:output, "/tmp")
+      end
 
       def reissue_an_order
         Digicert::OrderReissuer.create(order_params)

--- a/spec/acceptance/order_spec.rb
+++ b/spec/acceptance/order_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Order" do
 
   describe "finding an order" do
     it "finds a specific order based on the filters params" do
-      command = %w(order find -c ribosetest.com -p -s expired)
+      command = %w(order find -c ribosetest.com -s expired)
       allow(Digicert::CLI::Order).to receive_message_chain(:new, :find)
 
       Digicert::CLI.start(*command)


### PR DESCRIPTION
Currently, we have a `global options` array where we specify all of the options available, and if we look up the help documentation then it will provide some miss leading behavior as all options might not apply in all use case scenario.

This commit improve it a bit, but separating `global` and `local` options, so if some options are available in all of the resources then we will add that to `global_options` but if some options are specific to single resource then we will add that to that specific resource.

There are still some issue we can improve, like make the options to `subcommand` specific, but that will require quite some work, but compare to our use cases I feel it's should be okay for now, but if we need that then we can always add that later.