### PR TITLE
Generate `CSR` with custom details

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ To generate a new `CSR` using an existing order details we can use
 digicert csr generate -o 12345 --key full_path_to_the.key
 ```
 
+Generate `CSR` with `--common_name` and `san`
+
+```sh
+digicert csr generate --common_name ribosetest.com --order_id 1234 \
+  --san test1.ribosetest.com,test2.ribosetest.com, --key path_to_key_file
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/digicert-cli.gemspec
+++ b/digicert-cli.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   #
 
   spec.add_dependency "terminal-table"
+  spec.add_dependency "openssl", ">= 2.0.3"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "dotenv"

--- a/lib/digicert/cli.rb
+++ b/lib/digicert/cli.rb
@@ -1,4 +1,5 @@
 require "optparse"
+require "openssl"
 require "digicert"
 
 require "digicert/cli/util"

--- a/lib/digicert/cli/csr.rb
+++ b/lib/digicert/cli/csr.rb
@@ -16,7 +16,8 @@ module Digicert
       def self.local_options
         [
           ["-k", "--key KEY_FILE_PATH", "Path to the rsa key file"],
-          ["-r", "--crt CSR_FILE", "Full path for the csr file"]
+          ["-r", "--crt CSR_FILE", "Full path for the csr file"],
+          ["-n", "--san SAN", Array, "Subject Alternative Names"]
         ]
       end
 
@@ -34,11 +35,20 @@ module Digicert
 
       def generate_csr_for(order)
         if rsa_key && File.exists?(rsa_key)
-          Digicert::CSRGenerator.generate(
-            rsa_key: File.read(rsa_key),
-            organization: order.organization,
-            common_name: order.certificate.common_name
-          )
+          Digicert::CSRGenerator.generate(csr_attributes(order))
+        end
+      end
+
+      def csr_attributes(order)
+        Hash.new.tap do |csr|
+          csr[:rsa_key] = File.read(rsa_key)
+          csr[:organization] = order.organization
+          csr[:common_name] =
+            options[:common_name] || order.certificate.common_name
+
+          if options[:san]
+            csr[:san_names] = options[:san]
+          end
         end
       end
     end

--- a/spec/acceptance/csr_spec.rb
+++ b/spec/acceptance/csr_spec.rb
@@ -13,15 +13,40 @@ RSpec.describe "CSR" do
   end
 
   describe "generating CSR" do
-    it "generates a new CSR for an existing order" do
-      allow(Digicert::CLI::CSR).to receive_message_chain(:new, :generate)
-      command = %w(csr generate -o 123456 --key ./spec/fixtures/rsa4096.key)
+    context "with existing order" do
+      it "generates a new CSR for an existing order" do
+        allow(Digicert::CLI::CSR).to receive_message_chain(:new, :generate)
+        command = %w(csr generate -o 123456 --key ./spec/fixtures/rsa4096.key)
 
-      Digicert::CLI.start(*command)
+        Digicert::CLI.start(*command)
 
-      expect(Digicert::CLI::CSR).to have_received(:new).with(
-        order_id: "123456", key: "./spec/fixtures/rsa4096.key"
-      )
+        expect(Digicert::CLI::CSR).to have_received(:new).with(
+          order_id: "123456", key: "./spec/fixtures/rsa4096.key"
+        )
+      end
+    end
+
+    context "with provided details" do
+      it "generates a new CSR with the details" do
+        command = %w(
+        csr generate
+          --order_id 123456
+          --common_name ribosetest.com
+          --key ./spec/fixtures/rsa4096.key
+          --san site1.ribosetest.com,site2.ribosetest.com
+        )
+
+        allow(Digicert::CLI::CSR).to receive_message_chain(:new, :generate)
+
+        Digicert::CLI.start(*command)
+
+        expect(Digicert::CLI::CSR).to have_received(:new).with(
+          order_id: "123456",
+          common_name: "ribosetest.com",
+          key: "./spec/fixtures/rsa4096.key",
+          san: ["site1.ribosetest.com", "site2.ribosetest.com"]
+        )
+      end
     end
   end
 end

--- a/spec/digicert/csr_spec.rb
+++ b/spec/digicert/csr_spec.rb
@@ -14,15 +14,34 @@ RSpec.describe Digicert::CLI::CSR do
   end
 
   describe "#generate" do
-    it "generates a new csr for an existing order" do
-      order_id = 123456
-      key_file = "./spec/fixtures/rsa4096.key"
-      stub_digicert_order_fetch_api(order_id)
+    context "with existing order details" do
+      it "generates a new csr for an existing order" do
+        order_id = 123456
+        key_file = "./spec/fixtures/rsa4096.key"
+        stub_digicert_order_fetch_api(order_id)
 
-      csr = Digicert::CLI::CSR.new(order_id: order_id, key: key_file).generate
+        csr = Digicert::CLI::CSR.new(order_id: order_id, key: key_file).generate
 
-      expect(csr.start_with?("-----BEGIN CERTIFICATE REQUEST")).to be_truthy
-      expect(csr.end_with?("--END CERTIFICATE REQUEST-----\n")).to be_truthy
+        expect(csr.start_with?("-----BEGIN CERTIFICATE REQUEST")).to be_truthy
+        expect(csr.end_with?("--END CERTIFICATE REQUEST-----\n")).to be_truthy
+      end
+    end
+
+    context "with custom details" do
+      it "generates a new csr using the provided details" do
+        order_id = 123456
+        common_name = "ribosetest.com"
+        key_file = "./spec/fixtures/rsa4096.key"
+        san = ["site1.ribosetest.com", "site2.ribosetest.com"]
+        stub_digicert_order_fetch_api(order_id)
+
+        csr = Digicert::CLI::CSR.new(
+          order_id: order_id, common_name: common_name, san: san, key: key_file
+        ).generate
+
+        expect(csr.start_with?("-----BEGIN CERTIFICATE REQUEST")).to be_truthy
+        expect(csr.end_with?("--END CERTIFICATE REQUEST-----\n")).to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
This interface adds support to provide the details while creating a CSR, it adds support for `--san`, `--common_name` along with the other options, so if we provide the details then it will use those or else it will use the one from the specified order.

```sh
digicert csr generate --common_name ribosetest.com --order_id 1234 \
 --san test1.ribosetest.com,test2.ribosetest.com, --key key_file
```

Another important note: we also came across an issue for `opensssl` while we were adding support for `san_names`, which is solved in the latest version of openssl and that's the reason we are explicitly specify `openssl` lib and it's version.