### PR TITLE
Add interface to retrieve a certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ use the following interface.
 digicert order reissue --order_id 123456 --output /full/download/path
 ```
 
+### Certificate
+
+#### Fetch a certificate
+
+To fetch a certificate using the `order_id`, we can use the following interface,
+this interface also supports `--quite` option to fetch only the certificate id.
+
+```sh
+digicert certificate fetch --order_id 123456789 --quite
+```
+
 ### CSR
 
 #### Fetch an order's CSR

--- a/lib/digicert/cli/certificate.rb
+++ b/lib/digicert/cli/certificate.rb
@@ -1,0 +1,25 @@
+module Digicert
+  module CLI
+    class Certificate < Digicert::CLI::Base
+      def fetch
+        apply_ouput_flag(order.certificate)
+      end
+
+      def self.local_options
+        [
+          ["-q", "--quiet",  "Flag to return only the certificate Id"]
+        ]
+      end
+
+      private
+
+      def order
+        @order ||= Digicert::Order.fetch(order_id)
+      end
+
+      def apply_ouput_flag(certificate)
+        options[:quiet] ? certificate.id : certificate
+      end
+    end
+  end
+end

--- a/lib/digicert/cli/command.rb
+++ b/lib/digicert/cli/command.rb
@@ -1,6 +1,7 @@
 require "optparse"
-require "digicert/cli/order"
 require "digicert/cli/csr"
+require "digicert/cli/order"
+require "digicert/cli/certificate"
 
 module Digicert
   module CLI
@@ -17,7 +18,7 @@ module Digicert
       end
 
       def self.command_handlers
-        @commands ||= { order: "Order", csr: "CSR"}
+        @commands ||= { order: "Order", csr: "CSR", certificate: "Certificate" }
       end
 
       def self.command_handler(command)

--- a/spec/acceptance/certificate_spec.rb
+++ b/spec/acceptance/certificate_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe "Certificate" do
+  describe "fetch a certificate" do
+    it "returns certificate details for an order" do
+      command = %w(certificate find --order_id 123456 --quiet)
+      allow(Digicert::CLI::Certificate).to receive_message_chain(:new, :find)
+
+      Digicert::CLI.start(*command)
+
+      expect(
+        Digicert::CLI::Certificate,
+      ).to have_received(:new).with(order_id: "123456", quiet: true)
+    end
+  end
+end

--- a/spec/digicert/certificate_spec.rb
+++ b/spec/digicert/certificate_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.describe Digicert::CLI::Certificate do
+  describe "#fetch" do
+    context "with only order id" do
+      it "returns the details for the certificate" do
+        order_id = 123_456_789
+        stub_digicert_order_fetch_api(order_id)
+
+        certificate = Digicert::CLI::Certificate.new(
+          order_id: order_id
+        ).fetch
+
+        expect(certificate.id).not_to be_nil
+        expect(certificate.organization.id).not_to be_nil
+        expect(certificate.common_name).to eq("digicert.com")
+      end
+    end
+
+    context "with option attributes" do
+      it "returns the option attribute specified details" do
+        order_id = 112_358
+        stub_digicert_order_fetch_api(order_id)
+
+        certificate = Digicert::CLI::Certificate.new(
+          order_id: order_id, quiet: true
+        ).fetch
+
+        expect(certificate).to eq(order_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the interface to retrieve a certificate using the `order_id`, To retrieve a certificate we can use the `fetch` interface, this interface also supports `quite` option to return only the resource id.

```sh
digicert certificate fetch --order_id 123456
```