### PR TITLE
Add interface to download a certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ this interface also supports `--quite` option to fetch only the certificate id.
 digicert certificate fetch --order_id 123456789 --quite
 ```
 
+#### Download a certificate
+
+To download a certificate we can use the following interface, this will download
+the certificates to the provided paths.
+
+```sh
+digicert certificate fetch --order_id 123456 --output full_path_to_download
+```
+
 ### CSR
 
 #### Fetch an order's CSR

--- a/lib/digicert/cli/certificate.rb
+++ b/lib/digicert/cli/certificate.rb
@@ -2,22 +2,41 @@ module Digicert
   module CLI
     class Certificate < Digicert::CLI::Base
       def fetch
-        apply_ouput_flag(order.certificate)
+        apply_option_flags(order.certificate)
       end
 
       def self.local_options
         [
-          ["-q", "--quiet",  "Flag to return only the certificate Id"]
+          ["-q", "--quiet",  "Flag to return only the certificate Id"],
+          ["-p", "--output DOWNLOAD_PATH", "Path to download the certificate"]
         ]
       end
 
       private
 
+      attr_reader :output_path
+
+      def extract_local_attributes(options)
+        @output_path = options.fetch(:output, nil)
+      end
+
       def order
         @order ||= Digicert::Order.fetch(order_id)
       end
 
-      def apply_ouput_flag(certificate)
+      def apply_option_flags(certificate)
+        download(certificate) || apply_output_flag(certificate)
+      end
+
+      def download(certificate)
+        if output_path
+          Digicert::CLI::CertificateDownloader.download(
+            path: output_path, filename: order_id, certificate_id: certificate.id
+          )
+        end
+      end
+
+      def apply_output_flag(certificate)
         options[:quiet] ? certificate.id : certificate
       end
     end

--- a/spec/acceptance/certificate_spec.rb
+++ b/spec/acceptance/certificate_spec.rb
@@ -3,14 +3,27 @@ require "spec_helper"
 RSpec.describe "Certificate" do
   describe "fetch a certificate" do
     it "returns certificate details for an order" do
-      command = %w(certificate find --order_id 123456 --quiet)
-      allow(Digicert::CLI::Certificate).to receive_message_chain(:new, :find)
+      command = %w(certificate fetch --order_id 123456 --quiet)
+      allow(Digicert::CLI::Certificate).to receive_message_chain(:new, :fetch)
 
       Digicert::CLI.start(*command)
 
       expect(
         Digicert::CLI::Certificate,
       ).to have_received(:new).with(order_id: "123456", quiet: true)
+    end
+  end
+
+  describe "downloading a certificate" do
+    it "downloads the certificate to provided path" do
+      command = %w(certificate fetch --order_id 123456 --output /tmp/downloads)
+      allow(Digicert::CLI::Certificate).to receive_message_chain(:new, :fetch)
+
+      Digicert::CLI.start(*command)
+
+      expect(Digicert::CLI::Certificate).to have_received(:new).with(
+        order_id: "123456", output: "/tmp/downloads"
+      )
     end
   end
 end

--- a/spec/digicert/certificate_spec.rb
+++ b/spec/digicert/certificate_spec.rb
@@ -29,5 +29,23 @@ RSpec.describe Digicert::CLI::Certificate do
         expect(certificate).to eq(order_id)
       end
     end
+
+    context "output attribute specified" do
+      it "sends download message to certificate downloader" do
+        order_id = 112_358
+
+        stub_digicert_order_fetch_api(order_id)
+        allow(Digicert::CLI::CertificateDownloader).to receive(:download)
+
+        Digicert::CLI::Certificate.new(
+          order_id: order_id, output: "/tmp/downloads"
+        ).fetch
+
+        expect(Digicert::CLI::CertificateDownloader).
+          to have_received(:download).with({
+          certificate_id: 112358, filename: order_id, path: "/tmp/downloads"
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit adds the interface to download a certificate, it usages the existing `fetch` interface, and base on the `output` path value the CLI will download the certificates in the provided path.

```sh
digicert certificate fetch --order_id 123456 --output /tmp/downloads
```