### PR TITLE
Add interface to list duplicate certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ the certificates to the provided paths.
 digicert certificate fetch --order_id 123456 --output full_path_to_download
 ```
 
+#### List duplicate certificates
+
+If we need to list the duplicate certificates for any specific order then we can
+use the following interface, and it will list the duplicate certificates with
+some important attributes.
+
+```ruby
+digicert certificate duplicates --order_id 123456
+```
+
 ### CSR
 
 #### Fetch an order's CSR

--- a/spec/acceptance/certificate_spec.rb
+++ b/spec/acceptance/certificate_spec.rb
@@ -26,4 +26,20 @@ RSpec.describe "Certificate" do
       )
     end
   end
+
+  describe "listing duplicate certificates" do
+    it "returns the list of duplicate certificates" do
+      command = %w(certificate duplicates --order_id 123456)
+
+      allow(
+        Digicert::CLI::Certificate,
+      ).to receive_message_chain(:new, :duplicates)
+
+      Digicert::CLI.start(*command)
+
+      expect(
+        Digicert::CLI::Certificate,
+      ).to have_received(:new).with(order_id: "123456")
+    end
+  end
 end

--- a/spec/digicert/certificate_spec.rb
+++ b/spec/digicert/certificate_spec.rb
@@ -48,4 +48,17 @@ RSpec.describe Digicert::CLI::Certificate do
       end
     end
   end
+
+  describe "#duplicates" do
+    it "lists duplicate certificates" do
+      order_id = 112_358
+      allow(Digicert::DuplicateCertificate).to receive(:all)
+
+      Digicert::CLI::Certificate.new(order_id: order_id).duplicates
+
+      expect(
+        Digicert::DuplicateCertificate,
+      ).to have_received(:all).with(order_id: order_id)
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the interface to list the duplicate certificates for any of the valid `order_id`. Currently it will list duplicates with `id`, `comnon_name`, `san_names`, `status` and `validity`.

```sh
digicert certificate duplicates --order_id 123456789
```
Screentshot:

<img width="877" alt="screenshot 2017-06-13 14 47 14" src="https://user-images.githubusercontent.com/1220911/27071754-5534980c-5048-11e7-90f6-17f309894939.png">

