### PR TITLE
Download a specific certificate by its ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ the certificates to the provided paths.
 digicert certificate fetch --order_id 123456 --output full_path_to_download
 ```
 
+There is another interface only to download the certificate, this interface
+support both the `--order_id` and `--certificate_id`, so if we need to download
+any certificate by it's id then we can use this one
+
+```ruby
+digicert certificate download --order_id 654321 --output /downloads
+digicert certificate download --certificate_id 123456 --output /downloads
+```
+
 #### List duplicate certificates
 
 If we need to list the duplicate certificates for any specific order then we can

--- a/lib/digicert/cli/certificate.rb
+++ b/lib/digicert/cli/certificate.rb
@@ -11,9 +11,14 @@ module Digicert
         end
       end
 
+      def download
+        download_certificate(certificate_id)
+      end
+
       def self.local_options
         [
           ["-q", "--quiet",  "Flag to return only the certificate Id"],
+          ["-c", "--certificate_id CERTIFICATE_ID", "The certificate ID"],
           ["-p", "--output DOWNLOAD_PATH", "Path to download the certificate"]
         ]
       end
@@ -30,18 +35,24 @@ module Digicert
         @order ||= Digicert::Order.fetch(order_id)
       end
 
+      def certificate_id
+        @certificate_id ||= options[:certificate_id] || order.certificate.id
+      end
+
       def duplicate_certificates
         @certificates ||= Digicert::DuplicateCertificate.all(order_id: order_id)
       end
 
       def apply_option_flags(certificate)
-        download(certificate) || apply_output_flag(certificate)
+        download_certificate(certificate.id) || apply_output_flag(certificate)
       end
 
-      def download(certificate)
+      def download_certificate(certificate_id)
         if output_path
           Digicert::CLI::CertificateDownloader.download(
-            path: output_path, filename: order_id, certificate_id: certificate.id
+            path: output_path,
+            certificate_id: certificate_id,
+            filename: order_id || certificate_id,
           )
         end
       end

--- a/spec/acceptance/certificate_spec.rb
+++ b/spec/acceptance/certificate_spec.rb
@@ -42,4 +42,20 @@ RSpec.describe "Certificate" do
       ).to have_received(:new).with(order_id: "123456")
     end
   end
+
+  describe "downloading a certificate" do
+    it "downloads the certificate to output path" do
+      command = %w(certificate download --certificate_id 123 --output /tmp)
+
+      allow(
+        Digicert::CLI::Certificate,
+      ).to receive_message_chain(:new, :download)
+
+      Digicert::CLI.start(*command)
+
+      expect(
+        Digicert::CLI::Certificate,
+      ).to have_received(:new).with(certificate_id: "123", output: "/tmp")
+    end
+  end
 end

--- a/spec/digicert/certificate_spec.rb
+++ b/spec/digicert/certificate_spec.rb
@@ -61,4 +61,44 @@ RSpec.describe Digicert::CLI::Certificate do
       ).to have_received(:all).with(order_id: order_id)
     end
   end
+
+  describe "#download" do
+    context "with certificate_id" do
+      it "sends downloader a download message" do
+        certificate_id = 123_456_789
+        downloader = Digicert::CLI::CertificateDownloader
+        allow(downloader).to receive(:download)
+
+        Digicert::CLI::Certificate.new(
+          certificate_id: certificate_id, output: "/tmp/downloads",
+        ).download
+
+        expect(downloader).to have_received(:download).with(
+          hash_including(
+            certificate_id: certificate_id, filename: certificate_id,
+          ),
+        )
+      end
+    end
+
+    context "with order_id" do
+      it "fetch order and sends downloader a download message" do
+        order_id = 123_456_789
+        downloader = Digicert::CLI::CertificateDownloader
+
+        allow(downloader).to receive(:download)
+        stub_digicert_order_fetch_api(order_id)
+
+        Digicert::CLI::Certificate.new(
+          order_id: order_id, output: "/tmp/downloads",
+        ).download
+
+        expect(downloader).to have_received(:download).with(
+          hash_including(
+            filename: order_id, path: "/tmp/downloads", certificate_id: 112358,
+          ),
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Sometime we might need to download a certificate using it's `ID`. This commit adds the support to download a certificate by this and it also implemented the support for `order_id`, so now we can use this whenever we need to download a certificate by it's id or it's `order_id`.

```sh
digicert certificate download --order_id 654321 --output /downloads
digicert certificate download --certificate_id 12345 --output /downloads
```