### PR TITLE
Expose `digicert` executable in installation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in digicert-cli.gemspec
 gemspec
-
-gem "digicert", github: "riboseinc/digicert", ref: "f122a4b"

--- a/bin/digicert
+++ b/bin/digicert
@@ -16,7 +16,6 @@ class Gem::Specification
 end
 
 # start up the CLI
-require "bundler/setup"
 require "digicert/cli"
 
 Digicert::CLI.start(ARGV)

--- a/digicert-cli.gemspec
+++ b/digicert-cli.gemspec
@@ -20,20 +20,10 @@ Gem::Specification.new do |spec|
   spec.bindir        = "bin"
   spec.executables   = "digicert"
 
-  # Digicert gem dpendenceis
-  #
-  # We are developing this cli and the digicert gem at the same time
-  # and we might not instantly push the digicert gems to rubygems while
-  # we are adding any new features. So let's use the one from our github
-  # and once we are close to finalize then we will switch to the actual
-  # digicert gem from rubygems.
-  #
-  # spec.add_dependency "digicert", "~> 0.1.1"
-  #
-
-  spec.add_dependency "terminal-table"
   spec.add_dependency "thor", "~> 0.19.4"
+  spec.add_dependency "digicert", "~> 0.1.2"
   spec.add_dependency "openssl", ">= 2.0.3"
+  spec.add_dependency "terminal-table"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "dotenv"


### PR DESCRIPTION
So far we were using the `bin/digicert` directly from the `bin` directory, but we need to expose this during the installation, so anyone can use this directly.

To support this we need to add the binary to the user's load path, and the easiest way to do that is to add it as executable in the gem specification. This also changes `digicert` gem dependency to the actual gem instead of GitHub repo.