### PR TITLE
Delegate shell message printing to thor

### DIFF
--- a/lib/digicert/cli/certificate_downloader.rb
+++ b/lib/digicert/cli/certificate_downloader.rb
@@ -28,7 +28,7 @@ module Digicert
       end
 
       def write_certificate_contents(contents)
-        print_message("Downloaded certificate to:")
+        say("Downloaded certificate to:")
 
         write_to_path("root", contents[:root_certificate])
         write_to_path("certificate", contents[:certificate])
@@ -39,12 +39,12 @@ module Digicert
         certificate_name = [filename, key, "crt"].join(".")
         certificate_path = [path, certificate_name].join("/")
 
-        print_message(certificate_path)
+        say(certificate_path)
         File.open(certificate_path, "w") { |file| file.write(content) }
       end
 
-      def print_message(message)
-        Digicert::CLI::Util.print_message(message)
+      def say(message)
+        Digicert::CLI::Util.say(message)
       end
     end
   end

--- a/lib/digicert/cli/order_reissuer.rb
+++ b/lib/digicert/cli/order_reissuer.rb
@@ -45,8 +45,9 @@ module Digicert
       end
 
       def print_request_details(request)
-        request_id = request.id
-        puts "Reissue request #{request_id} created for order - #{order_id}"
+        Digicert::CLI::Util.say(
+          "Reissue request #{request.id} created for order - #{order_id}",
+        )
       end
 
       def fetch_and_download_certificate(reissued_order_id)

--- a/lib/digicert/cli/order_retriever.rb
+++ b/lib/digicert/cli/order_retriever.rb
@@ -25,7 +25,7 @@ module Digicert
       def fetch_order_in_interval
         number_of_times.to_i.times do |number|
           sleep wait_time.to_i
-          print_message("Fetch attempt #{number + 1}..")
+          say("Fetch attempt #{number + 1}..")
           order = Digicert::Order.fetch(order_id)
 
           if recently_reissued?(order.last_reissued_date)
@@ -40,8 +40,8 @@ module Digicert
         end
       end
 
-      def print_message(message)
-        Digicert::CLI::Util.print_message(message)
+      def say(message)
+        Digicert::CLI::Util.say(message)
       end
     end
   end

--- a/lib/digicert/cli/util.rb
+++ b/lib/digicert/cli/util.rb
@@ -12,8 +12,8 @@ module Digicert
         end
       end
 
-      def self.print_message(message)
-        puts(message)
+      def self.say(message, color = nil)
+        Thor::Shell::Basic.new.say(message, color)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@ require "bundler/setup"
 require "digicert/cli"
 require "digicert/rspec"
 
+Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/support/disable-logging.rb
+++ b/spec/support/disable-logging.rb
@@ -1,0 +1,12 @@
+module Digicert
+  module CLI
+    module Util
+      # In the test console, printing process related messages creates
+      # some unnecessary noices, this module method will temporarily
+      # disabled those extra noices from the log.
+      #
+      def self.say(_message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Now that we've included `thor`, its probably a good idea to delegate the shell printing behavior to `thor`, and this also cleanup some of the existing code that was not using the helper.

One another addition, this commit also adds a support helper which disabled the message printing from the test suite, so we should not see any more extra noises in the test log.