### PR TITLE
Fix table width issue for order listing

### DIFF
--- a/lib/digicert/cli/util.rb
+++ b/lib/digicert/cli/util.rb
@@ -3,7 +3,7 @@ require "terminal-table"
 module Digicert
   module CLI
     module Util
-      def self.make_it_pretty(headings:, rows:, table_wdith: 80)
+      def self.make_it_pretty(headings:, rows:, table_wdith: 100)
         Terminal::Table.new do |table|
           table.headings = headings
           table.style = { width: table_wdith }


### PR DESCRIPTION
If some orders are pending for processing then the table view breaks, as the width crosses more then `80` characters and we have set the default to `80`. This commit changes the default to `100`, so it should work fine in all of the use cases.