### PR TITLE
Rename reissuing order's option to `csr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ Lots of information? Well, if you don't need that much details and only need the
 
 To reissue a non-expired order we can use the `order reissue` command and pass
 the order id. By default it will reissue the order using the existing details
-but we can update that by passing the certificate CSR as`--crt`
+but we can update that by passing the certificate CSR as`--csr`
 
 ```sh
-$ digicert order reissue 12345 --crt path_to_the_new_csr.csr
+$ digicert order reissue 12345 --csr path_to_the_new_csr.csr
 ```
 
 ```sh

--- a/lib/digicert/cli/commands/order.rb
+++ b/lib/digicert/cli/commands/order.rb
@@ -21,7 +21,7 @@ module Digicert
         end
 
         desc "reissue ORDER_ID", "Reissue digicert order"
-        option :crt, desc: "The CSR content from a file"
+        option :csr, desc: "The CSR content from a file"
         option :output, aliases: "-o", desc: "Path to download certificates"
 
         def reissue(order_id)

--- a/lib/digicert/cli/order_reissuer.rb
+++ b/lib/digicert/cli/order_reissuer.rb
@@ -19,7 +19,7 @@ module Digicert
       attr_reader :csr_file, :output_path
 
       def extract_local_attributes(options)
-        @csr_file = options.fetch(:crt, nil)
+        @csr_file = options.fetch(:csr, nil)
         @output_path = options.fetch(:output, "/tmp")
       end
 

--- a/spec/acceptance/reissuing_order_spec.rb
+++ b/spec/acceptance/reissuing_order_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe "Order reissuing" do
     context "reissue with new csr" do
       it "reissues an order with the provided csr" do
         mock_digicert_order_reissuer_create_message_chain
-        command = %w(order reissue 123456 --crt ./spec/fixtures/rsa4096.csr)
+        command = %w(order reissue 123456 --csr ./spec/fixtures/rsa4096.csr)
 
         Digicert::CLI.start(command)
 
         expect(Digicert::CLI::OrderReissuer).to have_received(:new).
-          with(order_id: "123456", crt: "./spec/fixtures/rsa4096.csr")
+          with(order_id: "123456", csr: "./spec/fixtures/rsa4096.csr")
       end
     end
 

--- a/spec/digicert/cli/order_reissuer_spec.rb
+++ b/spec/digicert/cli/order_reissuer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Digicert::CLI::OrderReissuer do
         allow(Digicert::OrderReissuer).to receive(:create)
 
         Digicert::CLI::OrderReissuer.new(
-          order_id: order_id, crt: csr_file,
+          order_id: order_id, csr: csr_file,
         ).create
 
         expect(Digicert::OrderReissuer).to have_received(:create).with(


### PR DESCRIPTION
In the `order reissue` command we were using `--crt` option to accept the CSR file content, but it might be confusing sometime, so based on a recent comments we are renaming this option to `--csr`, so now we can reissue an order using

```ruby
digicert order reissue 12345 --csr path_to_the_new_csr.csr
```

Fixes #45