### PR TITLE
Fix order reissue/duplicate related issue

### DIFF
--- a/digicert-cli.gemspec
+++ b/digicert-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = "digicert"
 
   spec.add_dependency "thor", "~> 0.19.4"
-  spec.add_dependency "digicert", "~> 0.1.2"
+  spec.add_dependency "digicert", "~> 0.2.0"
   spec.add_dependency "openssl", ">= 2.0.3"
   spec.add_dependency "terminal-table"
 

--- a/lib/digicert/cli/order_reissuer.rb
+++ b/lib/digicert/cli/order_reissuer.rb
@@ -32,7 +32,7 @@ module Digicert
           order_params[:order_id] = order_id
 
           if csr_file && File.exists?(csr_file)
-            order_params[:certificate] = { csr: File.read(csr_file) }
+            order_params[:csr] = File.read(csr_file)
           end
         end
       end

--- a/spec/digicert/cli/order_reissuer_spec.rb
+++ b/spec/digicert/cli/order_reissuer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Digicert::CLI::OrderReissuer do
         ).create
 
         expect(Digicert::OrderReissuer).to have_received(:create).with(
-          order_id: order_id, certificate: { csr: File.read(csr_file) },
+          order_id: order_id, csr: File.read(csr_file),
         )
       end
     end
@@ -62,13 +62,11 @@ RSpec.describe Digicert::CLI::OrderReissuer do
 
   def order_attributes(order)
     {
-      certificate: {
-        common_name: order.certificate.common_name,
-        dns_names: order.certificate.dns_names,
-        csr: order.certificate.csr,
-        signature_hash: order.certificate.signature_hash,
-        server_platform: { id: 45 },
-      },
+      common_name: order.certificate.common_name,
+      dns_names: order.certificate.dns_names,
+      csr: order.certificate.csr,
+      signature_hash: order.certificate.signature_hash,
+      server_platform: { id: 45 },
     }
   end
 end


### PR DESCRIPTION
The Order `reissue` and `duplication` interface takes an order id and also the new attributes for the order. The way it supposed to work is if we add any custom attributes then it will use that with all others but if we don't then it will use the defaults.

It is working fine when no attributes are provided, but when we add custom attributes option then it is replacing all of the attributes with the new one, and which we found from the bug report 46.

This issue was from the Digicert gem, and we already fixed it there and then this commit upgrades the underlying gem and also add the required changes for that bug.