### PR TITLE
Remove confusing Key configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `CLI` commands are heavily dependent on the Digicert API. Please
 your API key then you can configure it using the `config` command.
 
 ```sh
-$ digicert config DIGICERT_API_KEY
+$ digicert config api-key YOUR_API_KEY
 ```
 
 ## Usages
@@ -39,7 +39,7 @@ $ digicert help
 ```sh
 Commands:
   digicert certificate     # Manage Digicert Certificates
-  digicert config API_KEY  # Configure The CLI Client
+  digicert config          # Configure The CLI Client
   digicert csr             # Fetch/generate Certificate CSR
   digicert help [COMMAND]  # Describe available / One specific command
   digicert order           # Manage Digicert Orders

--- a/lib/digicert/cli.rb
+++ b/lib/digicert/cli.rb
@@ -37,7 +37,7 @@ module Digicert
       Thor::Shell::Basic.new.say(
         "Invalid: Missing API KEY\n\n" \
         "A valid Digicert API key is required for any of the CLI operation\n" \
-        "You can set your API Key using `digicert config DIGICERT_API_KEY`",
+        "You can set your API Key using `digicert config api-key YOUR_API_KEY`",
       )
     end
   end

--- a/lib/digicert/cli/command.rb
+++ b/lib/digicert/cli/command.rb
@@ -1,6 +1,6 @@
-require "digicert/cli/rcfile"
 require "digicert/cli/commands/csr"
 require "digicert/cli/commands/order"
+require "digicert/cli/commands/config"
 require "digicert/cli/commands/certificate"
 
 module Digicert
@@ -15,10 +15,8 @@ module Digicert
       desc "certificate", "Manage Digicert Certificates"
       subcommand :certificate, Digicert::CLI::Commands::Certificate
 
-      desc "config API_KEY", "Configure The CLI Client"
-      def config(api_key)
-        Digicert::CLI::RCFile.set_key(api_key)
-      end
+      desc "config", "Configure The CLI Client"
+      subcommand :config, Digicert::CLI::Commands::Config
     end
   end
 end

--- a/lib/digicert/cli/commands/config.rb
+++ b/lib/digicert/cli/commands/config.rb
@@ -1,0 +1,14 @@
+require "digicert/cli/rcfile"
+
+module Digicert
+  module CLI
+    module Commands
+      class Config < Thor
+        desc "api-key API_KEY", "Configure Your Digicert API Key"
+        def api_key(api_key)
+          Digicert::CLI::RCFile.set_key(api_key)
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/config_spec.rb
+++ b/spec/acceptance/config_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe "Config" do
   describe "configuring key" do
     it "stores the provided api key" do
-      command = %w(config DIGICERT_SECRET_KEY)
+      command = %w(config api-key DIGICERT_SECRET_KEY)
       allow(Digicert::CLI::RCFile).to receive(:set_key)
 
       Digicert::CLI.start(command)


### PR DESCRIPTION
In the current version user runs `digicert config API_KEY` to set the API key, which might seems bit confusing as it does not says what exactly user is configuring.

This commit changes this configuration options to make it less confusing and it clearly specify the `api-key` with the config interface. New way to configure the API key is:

```sh
digicert config api-key YOUR_API_KEY
```