### PR TITLE
Fix certificate download related issue

### DIFF
--- a/lib/digicert/cli/commands/certificate.rb
+++ b/lib/digicert/cli/commands/certificate.rb
@@ -18,7 +18,9 @@ module Digicert
         option :output, aliases: "-o", desc: "Path to download the certificate"
 
         def download
-          say(certificate_instance.download)
+          required_option_exists? || say(certificate_instance.download)
+        rescue Digicert::Errors::RequestError
+          say("Invalid Resource ID")
         end
 
         desc "duplicates ORDER_ID", "List duplicate certificates"
@@ -30,6 +32,12 @@ module Digicert
 
         def certificate_instance(id_attribute = {})
           Digicert::CLI::Certificate.new(options.merge(id_attribute))
+        end
+
+        def required_option_exists?
+          unless options[:order_id] || options[:certificate_id]
+            say("You must provide either `--order_id` or `--certificate_id`.")
+          end
         end
       end
     end


### PR DESCRIPTION
The `certificate download` command expects us to provide the order id or certificate id, but does not necessarily force us to do anything and that's why it was throwing issues like we have on the Issue: #48.

This commit fixes it by adding a help method that will check either one of those option are exits, and it not then it will print out that custom message before calling the API.

This also add another error handling for invalid resource id, so if the user tries to download an invalid resource then it will print out the invalid resource related message.