### PR TITLE
Use the `pwd` as default download path

### DIFF
--- a/lib/digicert/cli/commands/certificate.rb
+++ b/lib/digicert/cli/commands/certificate.rb
@@ -15,7 +15,13 @@ module Digicert
         desc "download [RSOURCE_OPTION]", "Download a certificate"
         option :order_id, aliases: "-i", desc: "Digicert order ID"
         option :certificate_id, aliases: "-c", desc: "The certificate ID"
-        option :output, aliases: "-o", desc: "Path to download the certificate"
+
+        option(
+          :output,
+          aliases: "-o",
+          default: Dir.pwd,
+          desc: "Path to download the certificate",
+        )
 
         def download
           required_option_exists? || say(certificate_instance.download)


### PR DESCRIPTION
In the certificate download interface, user provides the `--output` option to specify the download path, but based on the recent issue we have decided to make it bit more flexible, if the user does not provide any `--output` option then we should download in present working directory.