### PR TITLE
Bump the gem version to `0.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 0.4.0 (2017-12-11)
+
+* Upgrade `digicert` gem with `rubocop` config
+
+## 0.1.0 - 0.3.0 (2017-10-16)
+
+* Initial fully functional release

--- a/lib/digicert/cli/version.rb
+++ b/lib/digicert/cli/version.rb
@@ -22,6 +22,6 @@
 
 module Digicert
   module CLI
-    VERSION = "0.3.0".freeze
+    VERSION = "0.4.0".freeze
   end
 end


### PR DESCRIPTION
* Upgrade digicert gem with rubocop config
* Add a changelog with previous highlights