### PR TITLE
Add order duplication support in CLI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in digicert-cli.gemspec
 gemspec
+
+# Temporary until there is a new release
+gem "digicert", github: "riboseinc/digicert", ref: "9d2915d"

--- a/digicert-cli.gemspec
+++ b/digicert-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = "digicert"
 
   spec.add_dependency "thor", "~> 0.19.4"
-  spec.add_dependency "digicert", "~> 0.3.1"
+  spec.add_dependency "digicert", "~> 0.4.0"
   spec.add_dependency "openssl", ">= 2.0.3"
   spec.add_dependency "terminal-table"
 
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.0"
+  spec.add_development_dependency "pry", "~> 0.11.3"
 end

--- a/lib/digicert/cli/commands/order.rb
+++ b/lib/digicert/cli/commands/order.rb
@@ -1,6 +1,7 @@
 require "digicert/cli/order"
 require "digicert/cli/order_reissuer"
 require "digicert/cli/order_creator"
+require "digicert/cli/order_duplicator"
 
 module Digicert
   module CLI
@@ -23,13 +24,15 @@ module Digicert
 
         desc "reissue ORDER_ID", "Reissue digicert order"
         option :csr, desc: "The CSR content from a file"
+        method_option :common_name, desc: "Certificate Common Name"
+        method_option :signature_hash, desc: "Certificate signature hash"
         option :output, aliases: "-o", desc: "Path to download certificates"
 
         def reissue(order_id)
           say(reissue_an_order(order_id))
         end
 
-        desc "create NAME_ID", "Create a new order"
+        desc "create", "Create a new order"
         method_option :csr, desc: "The CSR content from a file"
         method_option :common_name, desc: "Certificate Common Name"
         method_option :signature_hash, desc: "Certificate signature hash"
@@ -54,6 +57,16 @@ module Digicert
           say("Request Error: #{error}.")
         end
 
+        desc "duplicate ORDER_ID", "Duplicate digicert order"
+        option :csr, desc: "The CSR content from a file"
+        method_option :common_name, desc: "Certificate Common Name"
+        method_option :signature_hash, desc: "Certificate signature hash"
+        option :output, aliases: "-o", desc: "Path to download certificate"
+
+        def duplicate(order_id)
+          say(duplicate_an_order(order_id))
+        end
+
         private
 
         def order_instance
@@ -68,6 +81,12 @@ module Digicert
 
         def create_new_order(name_id, options)
           Digicert::CLI::OrderCreator.create(name_id, options)
+        end
+
+        def duplicate_an_order(order_id)
+          Digicert::CLI::OrderDuplicator.new(
+            options.merge(order_id: order_id),
+          ).create
         end
       end
     end

--- a/lib/digicert/cli/order_duplicator.rb
+++ b/lib/digicert/cli/order_duplicator.rb
@@ -1,0 +1,62 @@
+module Digicert
+  module CLI
+    class OrderDuplicator < Digicert::CLI::Base
+      def create
+        apply_output_options(duplicate_an_order)
+      end
+
+      private
+
+      attr_reader :csr_file, :output_path
+
+      def extract_local_attributes(options)
+        @csr_file = options.fetch(:csr, nil)
+        @output_path = options.fetch(:output, "/tmp")
+      end
+
+      def duplicate_an_order
+        Digicert::OrderDuplicator.create(order_params)
+      end
+
+      def order_params
+        Hash.new.tap do |order_params|
+          order_params[:order_id] = order_id
+
+          if csr_file && File.exists?(csr_file)
+            order_params[:csr] = File.read(csr_file)
+          end
+        end
+      end
+
+      def apply_output_options(duplicate)
+        if duplicate
+          print_request_details(duplicate.requests.first)
+          fetch_and_download_certificate(duplicate.requests.first.id)
+        end
+      end
+
+      def print_request_details(request)
+        Digicert::CLI::Util.say(
+          "Duplication request #{request.id} created for order - #{order_id}",
+        )
+      end
+
+      def fetch_and_download_certificate(request_id)
+        if options[:output]
+          certificate = fetch_certificate(request_id)
+          download_certificate_order(certificate.id)
+        end
+      end
+
+      def fetch_certificate(request_id)
+        Digicert::DuplicateCertificateFinder.find_by(request_id: request_id)
+      end
+
+      def download_certificate_order(certificate_id)
+        Digicert::CLI::CertificateDownloader.download(
+          filename: order_id, path: output_path, certificate_id: certificate_id,
+        )
+      end
+    end
+  end
+end

--- a/lib/digicert/cli/order_reissuer.rb
+++ b/lib/digicert/cli/order_reissuer.rb
@@ -1,8 +1,3 @@
-require "date"
-
-require "digicert/cli/order_retriever"
-require "digicert/cli/certificate_downloader"
-
 module Digicert
   module CLI
     class OrderReissuer < Digicert::CLI::Base

--- a/spec/acceptance/certificate_spec.rb
+++ b/spec/acceptance/certificate_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Certificate" do
       command = %w(certificate fetch 123456 --quiet)
       allow(certificate_klass).to receive_message_chain(:new, :fetch)
 
-      Digicert::CLI.start(command)
+      _output = capture_stdout { Digicert::CLI.start(command) }
 
       expect(certificate_klass.new).to have_received(:fetch)
       expect(certificate_klass).to have_received(:new).with(
@@ -20,7 +20,7 @@ RSpec.describe "Certificate" do
       command = %w(certificate fetch 123456 --output /tmp/downloads)
       allow(Digicert::CLI::Certificate).to receive_message_chain(:new, :fetch)
 
-      Digicert::CLI.start(command)
+      _output = capture_stdout { Digicert::CLI.start(command) }
 
       expect(Digicert::CLI::Certificate).to have_received(:new).with(
         order_id: "123456", output: "/tmp/downloads"
@@ -36,7 +36,7 @@ RSpec.describe "Certificate" do
         Digicert::CLI::Certificate,
       ).to receive_message_chain(:new, :duplicates)
 
-      Digicert::CLI.start(command)
+      _output = capture_stdout { Digicert::CLI.start(command) }
 
       expect(
         Digicert::CLI::Certificate,
@@ -52,7 +52,7 @@ RSpec.describe "Certificate" do
         Digicert::CLI::Certificate,
       ).to receive_message_chain(:new, :download)
 
-      Digicert::CLI.start(command)
+      _output = capture_stdout { Digicert::CLI.start(command) }
 
       expect(
         Digicert::CLI::Certificate,

--- a/spec/acceptance/config_spec.rb
+++ b/spec/acceptance/config_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "Config" do
   describe "configuring key" do
     it "stores the provided api key" do
       command = %w(config api-key DIGICERT_SECRET_KEY)
-      allow(Digicert::CLI::RCFile).to receive(:set_key)
 
-      Digicert::CLI.start(command)
+      allow(Digicert::CLI::RCFile).to receive(:set_key)
+      _output = capture_stdout { Digicert::CLI.start(command) }
 
       expect(
         Digicert::CLI::RCFile,

--- a/spec/acceptance/csr_spec.rb
+++ b/spec/acceptance/csr_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "CSR" do
       command = %w(csr fetch 123456)
       allow(Digicert::CLI::CSR).to receive_message_chain(:new, :fetch)
 
-      Digicert::CLI.start(command)
+      _output = capture_stdout { Digicert::CLI.start(command) }
 
       expect(Digicert::CLI::CSR).to have_received(:new).with(order_id: "123456")
     end
@@ -18,7 +18,7 @@ RSpec.describe "CSR" do
         allow(Digicert::CLI::CSR).to receive_message_chain(:new, :generate)
         command = %w(csr generate -o 123456 --key ./spec/fixtures/rsa4096.key)
 
-        Digicert::CLI.start(command)
+        _output = capture_stdout { Digicert::CLI.start(command) }
 
         expect(Digicert::CLI::CSR).to have_received(:new).with(
           order_id: "123456", key: "./spec/fixtures/rsa4096.key",
@@ -36,8 +36,7 @@ RSpec.describe "CSR" do
         )
 
         allow(Digicert::CLI::CSR).to receive_message_chain(:new, :generate)
-
-        Digicert::CLI.start(command)
+        _output = capture_stdout { Digicert::CLI.start(command) }
 
         expect(Digicert::CLI::CSR).to have_received(:new).with(
           order_id: "123456",

--- a/spec/acceptance/duplicating_order_spec.rb
+++ b/spec/acceptance/duplicating_order_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe "Order duplicating" do
+  describe "duplicate an order" do
+    context "duplicate with new csr" do
+      it "duplicate an order with provided csr" do
+        mock_digicert_order_duplication_message_chain
+        command = %w(order duplicate 123456 --csr ./spec/fixtures/rsa4096.csr)
+
+        _output = capture_stdout { Digicert::CLI.start(command) }
+
+        expect(Digicert::CLI::OrderDuplicator).to have_received(:new).
+          with(order_id: "123456", csr: "./spec/fixtures/rsa4096.csr")
+      end
+    end
+  end
+
+  def mock_digicert_order_duplication_message_chain
+    allow(Digicert::CLI::OrderDuplicator).
+      to receive_message_chain(:new, :create)
+  end
+end

--- a/spec/acceptance/order_spec.rb
+++ b/spec/acceptance/order_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "Order" do
   describe "listing orders" do
     it "retrieves the list of the orders" do
       command = %w(order list --filter common_name:*.ribostetest.com)
-      allow(Digicert::CLI::Order).to receive_message_chain(:new, :list)
 
-      Digicert::CLI.start(command)
+      allow(Digicert::CLI::Order).to receive_message_chain(:new, :list)
+      _output = capture_stdout { Digicert::CLI.start(command) }
 
       expect(Digicert::CLI::Order.new).to have_received(:list)
     end
@@ -15,9 +15,9 @@ RSpec.describe "Order" do
   describe "finding an order" do
     it "finds a specific order based on the filters params" do
       command = %w(order find --filter common_name:ribosetest.com)
-      allow(Digicert::CLI::Order).to receive_message_chain(:new, :find)
 
-      Digicert::CLI.start(command)
+      allow(Digicert::CLI::Order).to receive_message_chain(:new, :find)
+      _output = capture_stdout { Digicert::CLI.start(command) }
 
       expect(Digicert::CLI::Order.new).to have_received(:find)
     end
@@ -26,7 +26,9 @@ RSpec.describe "Order" do
   describe "creating an order" do
     context "with valid information" do
       it "creates a new certificate order" do
-        allow(Digicert::CLI::OrderCreator).to receive(:create)
+        allow(
+          Digicert::CLI::OrderCreator,
+        ).to receive(:create).and_return(double("order", id: 123_456))
 
         command = %w(
           order create ssl_plus
@@ -38,8 +40,9 @@ RSpec.describe "Order" do
             --payment-method card
         )
 
-        Digicert::CLI.start(command)
+        output = capture_stdout { Digicert::CLI.start(command) }
 
+        expect(output).to include("New Order Created! Oder Id")
         expect(Digicert::CLI::OrderCreator).to have_received(:create).
           with(
             "ssl_plus",

--- a/spec/acceptance/reissuing_order_spec.rb
+++ b/spec/acceptance/reissuing_order_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Order reissuing" do
         mock_digicert_order_reissuer_create_message_chain
         command = %w(order reissue 123456 --csr ./spec/fixtures/rsa4096.csr)
 
-        Digicert::CLI.start(command)
+        _output = capture_stdout { Digicert::CLI.start(command) }
 
         expect(Digicert::CLI::OrderReissuer).to have_received(:new).
           with(order_id: "123456", csr: "./spec/fixtures/rsa4096.csr")
@@ -19,7 +19,7 @@ RSpec.describe "Order reissuing" do
         mock_digicert_order_reissuer_create_message_chain
         command = %w(order reissue 123456 --output /tmp/downloads)
 
-        Digicert::CLI.start(command)
+        _output = capture_stdout { Digicert::CLI.start(command) }
 
         expect(Digicert::CLI::OrderReissuer).to have_received(:new).
           with(order_id: "123456", output: "/tmp/downloads")

--- a/spec/digicert/cli/order_duplicator_spec.rb
+++ b/spec/digicert/cli/order_duplicator_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+
+RSpec.describe Digicert::CLI::OrderDuplicator do
+  describe "#create" do
+    context "with a valid order id" do
+      it "sends create message to digicert order duplicator" do
+        order_id = 123_456
+        allow(Digicert::OrderDuplicator).to receive(:create)
+
+        Digicert::CLI::OrderDuplicator.new(order_id: order_id).create
+
+        expect(
+          Digicert::OrderDuplicator,
+        ).to have_received(:create).with(order_id: order_id)
+      end
+    end
+
+    context "with order id and new csr" do
+      it "sends create message to duplicator with new csr" do
+        order_id = 123_456
+        csr_file = "./spec/fixtures/rsa4096.csr"
+        allow(Digicert::OrderDuplicator).to receive(:create)
+
+        Digicert::CLI::OrderDuplicator.new(
+          order_id: order_id, csr: csr_file,
+        ).create
+
+        expect(Digicert::OrderDuplicator).to have_received(:create).with(
+          order_id: order_id, csr: File.read(csr_file),
+        )
+      end
+    end
+
+    context "with order id and --fetch option" do
+      it "duplicates order and fetch the updated order" do
+        order_id = 456_789
+
+        mock_order_fetch_and_download_requests(order)
+        stub_digicert_order_duplicate_api(order_id, order_attributes(order))
+        allow(Digicert::CLI::CertificateDownloader).to receive(:download)
+
+        Digicert::CLI::OrderDuplicator.new(
+          order_id: order_id, output: "/tmp", number_of_times: 1, wait_time: 1,
+        ).create
+
+        expect(Digicert::CLI::CertificateDownloader).
+          to have_received(:download).
+          with(hash_including(certificate_id: order.certificate.id))
+      end
+    end
+
+    def order(order_id = 123_456)
+      stub_digicert_order_fetch_api(order_id)
+      @order ||= Digicert::Order.fetch(order_id)
+    end
+
+    def order_attributes(order)
+      {
+        common_name: order.certificate.common_name,
+        dns_names: order.certificate.dns_names,
+        csr: order.certificate.csr,
+        signature_hash: order.certificate.signature_hash,
+        server_platform: { id: 45 },
+      }
+    end
+
+    def mock_order_fetch_and_download_requests(order)
+      allow(Digicert::Order).to receive(:fetch).and_return(order)
+
+      allow(
+        Digicert::DuplicateCertificateFinder,
+      ).to receive(:find_by).and_return(order.certificate)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+  config.include Digicert::ConsoleHelper
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/console_helper.rb
+++ b/spec/support/console_helper.rb
@@ -1,0 +1,29 @@
+module Digicert
+  module ConsoleHelper
+    def capture_stdout(&_block)
+      original_stdout = $stdout
+      $stdout = fake = StringIO.new
+
+      begin
+        yield
+      ensure
+        $stdout = original_stdout
+      end
+
+      fake.string
+    end
+
+    def capture_stderr(&_block)
+      original_stderr = $stderr
+      $stderr = fake = StringIO.new
+
+      begin
+        yield
+      ensure
+        $stderr = original_stderr
+      end
+
+      fake.string
+    end
+  end
+end


### PR DESCRIPTION
There is an interface to duplicate an order in the DigiCert gem, but we didn't have any support to do that from the CLI. This commit adds the interface so the user can duplicate an order directly from
the CLI. Here are the details for this interface.

```
Usage:
  digicert order duplicate ORDER_ID

Options:
      [--csr=CSR]                        # The CSR content from a file
      [--common-name=COMMON_NAME]        # Certificate Common Name
      [--signature-hash=SIGNATURE_HASH]  # Certificate signature hash
  -o, [--output=OUTPUT]                  # Path to download certificate

Duplicate a Digicert Order
```

Fixes #49