### PR TITLE
Add `order create` interface in the gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,4 @@
 AllCops:
-  Include:
-    - "**/*.rake"
-    - "**/Gemfile"
-    - "**/Rakefile"
-
   Exclude:
     - db/schema.rb
 
@@ -357,8 +352,18 @@ Style/TrailingCommaInArguments:
     - no_comma
   Enabled: true
 
-Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in array and hash literals.'
+Style/TrailingCommaInArrayLiteral:
+  Description: 'Checks for trailing comma in array literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  Description: 'Checks for trailing comma in hash literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
@@ -401,6 +406,13 @@ Style/WordArray:
 Layout/AlignParameters:
   Description: 'Here we check if the parameters on a multi-line method call or definition are aligned.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
+  Enabled: false
+
+Layout/ConditionPosition:
+  Description: >-
+                 Checks for condition placed in a confusing position relative to
+                 the keyword.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
   Enabled: false
 
 Layout/DotPosition:
@@ -455,13 +467,6 @@ Lint/CircularArgumentReference:
   Description: "Don't refer to the keyword argument in the default value."
   Enabled: false
 
-Lint/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
-  Enabled: false
-
 Lint/DeprecatedClassMethods:
   Description: 'Check for deprecated class method calls.'
   Enabled: false
@@ -487,7 +492,7 @@ Lint/HandleExceptions:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: false
 
-Lint/LiteralInCondition:
+Lint/LiteralAsCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: false
 
@@ -528,7 +533,7 @@ Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: false
 
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
   Description: >-
                  Checks for rubocop:disable comments that can be removed.
                  Note: this cop is not disabled when disabling all cops.

--- a/lib/digicert/cli/commands/order.rb
+++ b/lib/digicert/cli/commands/order.rb
@@ -1,5 +1,6 @@
 require "digicert/cli/order"
 require "digicert/cli/order_reissuer"
+require "digicert/cli/order_creator"
 
 module Digicert
   module CLI
@@ -28,6 +29,31 @@ module Digicert
           say(reissue_an_order(order_id))
         end
 
+        desc "create NAME_ID", "Create a new order"
+        method_option :csr, desc: "The CSR content from a file"
+        method_option :common_name, desc: "Certificate Common Name"
+        method_option :signature_hash, desc: "Certificate signature hash"
+        method_option :organization_id, desc: "The Organization ID"
+        method_option :validity_years, desc: "Validity years for certificate"
+        method_option :comments, desc: "Comments about the certificate order"
+        method_option :payment_method, desc: "Speicfy the payment method"
+
+        method_option :disable_renewal_notifications, type: :boolean
+        method_option :server_platform_id, desc: "Server Platform Id"
+        method_option :profile_option, desc: "Specify certificate profile"
+        method_option :organization_units, type: :array, desc: "organization_units"
+        method_option :custom_expiration_date, desc: "Expiry Date in YYY-MM-DD"
+        method_option :renewal_of_order_id, desc: "Id for renewalable Order"
+        method_option :disable_ct, type: :boolean, desc: "Disable CT logging"
+
+        def create(name_id)
+          order = create_new_order(name_id, options)
+          say("New Order Created! Oder Id: #{order.id}.")
+
+        rescue Digicert::Errors::RequestError => error
+          say("Request Error: #{error}.")
+        end
+
         private
 
         def order_instance
@@ -38,6 +64,10 @@ module Digicert
           Digicert::CLI::OrderReissuer.new(
             options.merge(order_id: order_id),
           ).create
+        end
+
+        def create_new_order(name_id, options)
+          Digicert::CLI::OrderCreator.create(name_id, options)
         end
       end
     end

--- a/lib/digicert/cli/order_creator.rb
+++ b/lib/digicert/cli/order_creator.rb
@@ -1,0 +1,58 @@
+module Digicert
+  module CLI
+    class OrderCreator < Digicert::CLI::Base
+      def initialize(name_id, attributes)
+        @name_id = name_id
+        @attributes = attributes
+      end
+
+      def create
+        create_order
+      end
+
+      def self.create(name_id, attributes)
+        new(name_id, attributes).create
+      end
+
+      private
+
+      attr_reader :name_id, :attributes
+
+      def create_order
+        Digicert::Order.create(name_id, order_attributes)
+      end
+
+      def csr_file_content(csr_file)
+        if csr_file && File.exists?(csr_file)
+          File.read(csr_file)
+        end
+      end
+
+      def organization
+        Digicert::Organization.all.last
+      end
+
+      def order_attributes
+        {
+          certificate: {
+            common_name: attributes[:common_name],
+            csr: csr_file_content(attributes[:csr]),
+            signature_hash: attributes[:signature_hash],
+            organization_units: attributes[:organization_units],
+            server_platform: { id: attributes[:server_platform_id] },
+            profile_option: attributes[:profile_option],
+          },
+
+          organization: { id: attributes[:organization_id] || organization.id },
+          validity_years: attributes[:validity_years] || 3,
+          custom_expiration_date: attributes[:custom_expiration_date],
+          comments: attributes[:comments],
+          disable_renewal_notifications: attributes[:disable_renewal_notifications],
+          renewal_of_order_id: attributes[:renewal_of_order_id],
+          payment_method: attributes[:payment_method],
+          disable_ct: attributes[:disable_ct],
+        }
+      end
+    end
+  end
+end

--- a/spec/acceptance/order_spec.rb
+++ b/spec/acceptance/order_spec.rb
@@ -22,4 +22,35 @@ RSpec.describe "Order" do
       expect(Digicert::CLI::Order.new).to have_received(:find)
     end
   end
+
+  describe "creating an order" do
+    context "with valid information" do
+      it "creates a new certificate order" do
+        allow(Digicert::CLI::OrderCreator).to receive(:create)
+
+        command = %w(
+          order create ssl_plus
+            --csr ./spec/fixtures/rsa4096.csr
+            --common-name ribosetest.com
+            --signature-hash sha512
+            --organization-id 123456
+            --validity-years 3
+            --payment-method card
+        )
+
+        Digicert::CLI.start(command)
+
+        expect(Digicert::CLI::OrderCreator).to have_received(:create).
+          with(
+            "ssl_plus",
+            "csr" => "./spec/fixtures/rsa4096.csr",
+            "common_name" => "ribosetest.com",
+            "signature_hash" => "sha512",
+            "organization_id" => "123456",
+            "validity_years" => "3",
+            "payment_method" => "card",
+          )
+      end
+    end
+  end
 end

--- a/spec/digicert/cli/order_creator_spec.rb
+++ b/spec/digicert/cli/order_creator_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+RSpec.describe Digicert::CLI::OrderCreator do
+  describe ".create" do
+    context "with valid order information" do
+      it "creates a new digicert certificate order" do
+        name_id = "ssl_plus"
+        stub_digicert_order_create_api(
+          name_id, rest_order_attributes(order_attributes)
+        )
+
+        order = Digicert::CLI::OrderCreator.create(name_id, order_attributes)
+
+        expect(order.id).not_to be_nil
+        expect(order.requests.first.status).to eq("pending")
+      end
+    end
+  end
+
+  def order_attributes
+    @order_attributes ||= {
+      common_name: "ribosetest.com",
+      csr: "./spec/fixtures/rsa4096.csr",
+      signature_hash: "sha512",
+      organization_units: "Developer Units",
+      server_platform_id: "platform_id_101",
+      profile_option: "certificate-profile",
+      organization_id: "organization-id",
+      validity_years: 3,
+      custom_expiration_date: "11-11-2019",
+      comments: "Ordered using digicert CLI",
+      disable_renewal_notifications: false,
+      renewal_of_order_id: 123456,
+      payment_method: "balanace",
+      disable_ct: false,
+    }
+  end
+
+  def rest_order_attributes(attributes)
+    {
+      certificate: {
+        organization_units: attributes[:organization_units],
+        server_platform: { id: attributes[:server_platform_id] },
+        profile_option: attributes[:profile_option],
+        csr: File.read(attributes[:csr]),
+        common_name: attributes[:common_name],
+        signature_hash: attributes[:signature_hash],
+      },
+
+      organization: { id: attributes[:organization_id] },
+      validity_years: attributes[:validity_years],
+      custom_expiration_date: attributes[:custom_expiration_date],
+      comments: attributes[:comments],
+      disable_renewal_notifications: attributes[:disable_renewal_notifications],
+      renewal_of_order_id: attributes[:renewal_of_order_id],
+      payment_method: attributes[:payment_method],
+      disable_ct: attributes[:disable_ct],
+    }
+  end
+end


### PR DESCRIPTION
Currently, we don't have a way to create new order through the Digicert CLI. So, this commit adds `order create` interface and it takes a `product_name_id` as an argument and also the others
attributes as an option.

For valid data, it creates the new order and finally prints out the `order_id`, but if order creation was filed then it returns an error message with the missing fields. For available options please check `order create --help`

<img width="875" alt="screenshot 2018-10-26 17 14 56" src="https://user-images.githubusercontent.com/1220911/47575571-b276d000-d942-11e8-97df-1314493a5332.png">

Closes #59 