### PR TITLE
Add `--debug` flag with CLI commands

### DIFF
--- a/lib/digicert/cli.rb
+++ b/lib/digicert/cli.rb
@@ -32,7 +32,7 @@ require "digicert/cli/command"
 module Digicert
   module CLI
     def self.start(arguments)
-      Digicert::CLI::Command.start(arguments)
+      Digicert::CLI::Util.run(arguments)
     rescue Digicert::Errors::Forbidden, NoMethodError
       Thor::Shell::Basic.new.say(
         "Invalid: Missing API KEY\n\n" \

--- a/lib/digicert/cli/commands/certificate.rb
+++ b/lib/digicert/cli/commands/certificate.rb
@@ -4,6 +4,8 @@ module Digicert
   module CLI
     module Commands
       class Certificate < Thor
+        class_option :debug, type: "boolean", desc: "Enable debug mode"
+
         desc "fetch ORDER_ID", "Find an order's certificate"
         option :quiet, type: :boolean, aliases: "-q", desc: "Retrieve only id"
         option :output, aliases: "-o", desc: "Path to download the certificate"

--- a/lib/digicert/cli/commands/csr.rb
+++ b/lib/digicert/cli/commands/csr.rb
@@ -4,8 +4,9 @@ module Digicert
   module CLI
     module Commands
       class Csr < Thor
-        desc "fetch ORDER_ID", "Fetch an existing CSR"
+        class_option :debug, type: "boolean", desc: "Enable debug mode"
 
+        desc "fetch ORDER_ID", "Fetch an existing CSR"
         def fetch(order_id)
           say(csr_instance(order_id: order_id).fetch)
         end

--- a/lib/digicert/cli/commands/order.rb
+++ b/lib/digicert/cli/commands/order.rb
@@ -7,6 +7,8 @@ module Digicert
   module CLI
     module Commands
       class Order < Thor
+        class_option :debug, type: "boolean", desc: "Enable debug mode"
+
         desc "list", "List digicert orders"
         method_option :filter, type: :hash, desc: "Specify filter options"
 

--- a/lib/digicert/cli/util.rb
+++ b/lib/digicert/cli/util.rb
@@ -1,3 +1,4 @@
+require "digicert"
 require "terminal-table"
 
 module Digicert
@@ -12,6 +13,19 @@ module Digicert
 
       def self.say(message, color = nil)
         Thor::Shell::Basic.new.say(message, color)
+      end
+
+      def self.run(arguments)
+        if arguments.include?("--debug")
+          arguments.delete("--debug")
+
+          Digicert.configuration.debug_mode = true
+          Digicert::CLI::Command.start(arguments)
+          Digicert.configuration.debug_mode = true
+        else
+
+          Digicert::CLI::Command.start(arguments)
+        end
       end
     end
   end


### PR DESCRIPTION
Currently, in the Digicert Gem we have an option to turn on or off that `debug_mode`. Based on this one each of the network request will print out all the important details which is very useful for debugging.

But, we did not have any support for that in the CLI, so this commit adds the `--debug` flag with all of the supported commands so now we can pass that and it will print out the details when necessary.

Fixes #37