### PR TITLE
Change CSR's Order Id to be optional

### DIFF
--- a/lib/digicert/cli/commands/csr.rb
+++ b/lib/digicert/cli/commands/csr.rb
@@ -12,10 +12,11 @@ module Digicert
         end
 
         desc "generate", "Generate certificate CSR"
+        option :order_id, aliases: "-o", desc: "An Order ID"
         option :common_name, aliases: "-c", desc: "The common name"
+        option :organization_id, desc: "Your digicert's organization ID"
         option :san, type: :array, desc: "The subject alternative names"
         option :key, aliases: "-k", desc: "Complete path to the rsa key file"
-        option :order_id, required: true, aliases: "-o", desc: "An Order ID"
 
         def generate
           say(csr_instance.generate)

--- a/lib/digicert/cli/csr.rb
+++ b/lib/digicert/cli/csr.rb
@@ -8,24 +8,38 @@ module Digicert
       end
 
       def generate
-        if order
-          generate_csr_for(order)
+        if order || valid_data?
+          generate_new_csr
         end
       end
 
       private
 
-      attr_reader :rsa_key
+      attr_reader :rsa_key, :organization_id, :common_name
 
       def extract_local_attributes(options)
         @rsa_key = options.fetch(:key, nil)
+        @common_name = options.fetch(:common_name, nil)
+        @organization_id = options.fetch(:organization_id, nil)
+      end
+
+      def valid_data?
+        !organization.nil? && !options[:common_name].nil?
       end
 
       def order
-        @order ||= Digicert::Order.fetch(order_id)
+        if order_id
+          @order ||= Digicert::Order.fetch(order_id)
+        end
       end
 
-      def generate_csr_for(order)
+      def organization
+        if organization_id
+          @organization ||= Digicert::Organization.fetch(organization_id)
+        end
+      end
+
+      def generate_new_csr
         if rsa_key && File.exists?(rsa_key)
           Digicert::CSRGenerator.generate(csr_attributes(order))
         end
@@ -34,9 +48,8 @@ module Digicert
       def csr_attributes(order)
         Hash.new.tap do |csr|
           csr[:rsa_key] = File.read(rsa_key)
-          csr[:organization] = order.organization
-          csr[:common_name] =
-            options[:common_name] || order.certificate.common_name
+          csr[:organization] = organization || order.organization
+          csr[:common_name] = common_name || order.certificate.common_name
 
           if options[:san]
             csr[:san_names] = options[:san]

--- a/spec/acceptance/csr_spec.rb
+++ b/spec/acceptance/csr_spec.rb
@@ -23,13 +23,14 @@ RSpec.describe "CSR" do
         expect(Digicert::CLI::CSR).to have_received(:new).with(
           order_id: "123456", key: "./spec/fixtures/rsa4096.key",
         )
-      end end
+      end
+    end
 
     context "with provided details" do
       it "generates a new CSR with the details" do
         command = %w(
           csr generate
-          --order-id 123456
+          --organization_id 1234
           --common_name ribosetest.com
           --key ./spec/fixtures/rsa4096.key
           --san site1.ribosetest.com site2.ribosetest.com
@@ -39,7 +40,7 @@ RSpec.describe "CSR" do
         _output = capture_stdout { Digicert::CLI.start(command) }
 
         expect(Digicert::CLI::CSR).to have_received(:new).with(
-          order_id: "123456",
+          organization_id: "1234",
           common_name: "ribosetest.com",
           key: "./spec/fixtures/rsa4096.key",
           san: ["site1.ribosetest.com", "site2.ribosetest.com"],

--- a/spec/digicert/cli/csr_spec.rb
+++ b/spec/digicert/cli/csr_spec.rb
@@ -29,14 +29,17 @@ RSpec.describe Digicert::CLI::CSR do
 
     context "with custom details" do
       it "generates a new csr using the provided details" do
-        order_id = 123456
+        organization_id = 123456
         common_name = "ribosetest.com"
         key_file = "./spec/fixtures/rsa4096.key"
         san = ["site1.ribosetest.com", "site2.ribosetest.com"]
-        stub_digicert_order_fetch_api(order_id)
+        stub_digicert_organization_fetch_api(organization_id)
 
         csr = Digicert::CLI::CSR.new(
-          order_id: order_id, common_name: common_name, san: san, key: key_file,
+          san: san,
+          key: key_file,
+          common_name: common_name,
+          organization_id: organization_id,
         ).generate
 
         expect(csr.start_with?("-----BEGIN CERTIFICATE REQUEST")).to be_truthy


### PR DESCRIPTION
Currently, we are forcing user to provide an order id to generate new CSR. We are doing it so we can gather the missing informations using that order id and then use those as a replacement for field like `common_name` or `organization` details.

But since it's not necessary, so let's change that in a way that user can choose to provide all the other details by themself.

Fixes: #63