### PR TITLE
Fix invalid table width argument issue

### DIFF
--- a/lib/digicert/cli.rb
+++ b/lib/digicert/cli.rb
@@ -33,8 +33,13 @@ module Digicert
   module CLI
     def self.start(arguments)
       Digicert::CLI::Util.run(arguments)
+
+    rescue Digicert::Errors::RequestError => error
+      Digicert::CLI::Util.say(
+        "A request to Digicert API failed\nError: #{error}",
+      )
     rescue Digicert::Errors::Forbidden, NoMethodError
-      Thor::Shell::Basic.new.say(
+      Digicert::CLI::Util.say(
         "Invalid: Missing API KEY\n\n" \
         "A valid Digicert API key is required for any of the CLI operation\n" \
         "You can set your API Key using `digicert config api-key YOUR_API_KEY`",

--- a/lib/digicert/cli/certificate.rb
+++ b/lib/digicert/cli/certificate.rb
@@ -65,7 +65,6 @@ module Digicert
         end
 
         Digicert::CLI::Util.make_it_pretty(
-          table_wdith: 100,
           rows: certificates_attributes,
           headings: ["Id", "Common Name", "SAN Names", "Status", "Validity"],
         )


### PR DESCRIPTION
Earlier, we removed the `table_width` option from our Util class, but we didn't update one existing class that was using that specific argument, This is causing some issue like #65

Since our table are much more flexible now, so this commit remove that argument and this should fix the issue.

Fixes #65