### PR TITLE
Fix certificate download related issue

### DIFF
--- a/digicert-cli.gemspec
+++ b/digicert-cli.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "openssl", ">= 2.0.3"
   spec.add_dependency "terminal-table"
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.0"

--- a/lib/digicert/cli/certificate.rb
+++ b/lib/digicert/cli/certificate.rb
@@ -1,3 +1,5 @@
+require "digicert/cli/certificate_downloader"
+
 module Digicert
   module CLI
     class Certificate < Digicert::CLI::Base

--- a/spec/digicert/cli/certificate_downloader_spec.rb
+++ b/spec/digicert/cli/certificate_downloader_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "digicert/cli/certificate_downloader"
 
 RSpec.describe Digicert::CLI::CertificateDownloader do
   describe ".download" do


### PR DESCRIPTION
For some reason, we missed to include the certificate downloader and that is what was causing the failures. Our test suite also seemed to be working unless we ran that specific test file.

Turn's out we were including that downloader file from a spec file and that's why it was not being reported. This commit fixes that by adding that downloader to our certificate interface.

Fixes #67